### PR TITLE
Fixes to Xiaomi power configuration cluster.

### DIFF
--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -94,10 +94,8 @@ class BasicCluster(CustomCluster, Basic):
         """calculate percentage."""
         min_voltage = 2500
         max_voltage = 3000
-        percent = (voltage - min_voltage) / (max_voltage - min_voltage) * 100
-        if percent > 100:
-            percent = 100
-        return percent
+        percent = (voltage - min_voltage) / (max_voltage - min_voltage) * 200
+        return min(200, percent)
 
 
 class PowerConfigurationCluster(LocalDataCluster, PowerConfiguration):
@@ -120,7 +118,8 @@ class PowerConfigurationCluster(LocalDataCluster, PowerConfiguration):
 
     def battery_reported(self, voltage, rawVoltage):
         self._update_attribute(BATTERY_PERCENTAGE_REMAINING, voltage)
-        self._update_attribute(BATTERY_VOLTAGE_MV, rawVoltage)
+        self._update_attribute(self.BATTERY_VOLTAGE_ATTR,
+                               int(rawVoltage / 100))
 
 
 class TemperatureMeasurementCluster(LocalDataCluster, TemperatureMeasurement):


### PR DESCRIPTION
'battery_percentage_remaining' attribute should use scale of 200 for
100% of battery remaining.
Xiaomi battery report battery in mV, but ZCL specs it in 100mV (0.1v -
30 == 3.0V)
Use battery_voltage attribute_id for battery voltage updates.