### PR TITLE
Add comment comparing ZHA Device Handlers to Zigbee-Shepherd Converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ZHA Device Handlers are custom quirks implementations for [Zigpy](https://github.com/zigpy/zigpy), the library that provides the [Zigbee](http://www.zigbee.org) support for the [ZHA](https://www.home-assistant.io/components/zha/) component in [Home Assistant](https://www.home-assistant.io).
 
-Custom quirks implementations for zigpy implemented as ZHA Device Handlers are similar to [Hub-connected Device Handlers for the SmartThings Classics platform](https://docs.smartthings.com/en/latest/device-type-developers-guide/), meaning they are virtual representation of a physical device that expose additional functionality that is not provided out-of-the-box by the existing integration between these platforms. See [Device Specifics](#Device-Specifics) for details.
+Custom quirks implementations for zigpy implemented as ZHA Device Handlers are a similar concept to that of [Hub-connected Device Handlers for the SmartThings Classics platform](https://docs.smartthings.com/en/latest/device-type-developers-guide/) as well that of [https://github.com/Koenkk/zigbee-shepherd-converters](zigbee-shepherd-converters as used by Zigbee2mqtt), meaning they are virtual representation of a physical device that expose additional functionality that is not provided out-of-the-box by the existing integration between these platforms. See [Device Specifics](#Device-Specifics) for details.
 
 #
 # Currently Supported Devices:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ZHA Device Handlers are custom quirks implementations for [Zigpy](https://github.com/zigpy/zigpy), the library that provides the [Zigbee](http://www.zigbee.org) support for the [ZHA](https://www.home-assistant.io/components/zha/) component in [Home Assistant](https://www.home-assistant.io).
 
-Custom quirks implementations for zigpy implemented as ZHA Device Handlers are a similar concept to that of [Hub-connected Device Handlers for the SmartThings Classics platform](https://docs.smartthings.com/en/latest/device-type-developers-guide/) as well that of [https://github.com/Koenkk/zigbee-shepherd-converters](zigbee-shepherd-converters as used by Zigbee2mqtt), meaning they are virtual representation of a physical device that expose additional functionality that is not provided out-of-the-box by the existing integration between these platforms. See [Device Specifics](#Device-Specifics) for details.
+Custom quirks implementations for zigpy implemented as ZHA Device Handlers are a similar concept to that of [Hub-connected Device Handlers for the SmartThings Classics platform](https://docs.smartthings.com/en/latest/device-type-developers-guide/) as well that of [Zigbee-Shepherd Converters as used by Zigbee2mqtt](https://github.com/Koenkk/zigbee-shepherd-converters), meaning they are virtual representation of a physical device that expose additional functionality that is not provided out-of-the-box by the existing integration between these platforms. See [Device Specifics](#Device-Specifics) for details.
 
 #
 # Currently Supported Devices:


### PR DESCRIPTION
Update README.md adding comment comparing ZHA Device Handlers to that of zigbee-shepherd-converters as used by the Zigbee2mqtt project in addition to the existing comparison to that of Hub-connected Device Handlers for the SmartThings Classics platform. 

I did not, however, know if the README.md for ZHA Device Handlers should point to http://www.zigbee2mqtt.io/how_tos/how_to_support_new_devices.html instead of https://github.com/Koenkk/zigbee-shepherd-converters when linking to it for this comparison?

Regardless, I hope that is a good and fair comparison? 

By the way, you might notice that the Zigbee2mqtt project has written that great guide on how to add support for new devices by creating Zigbee-Shepherd Converters for the Zigbee2mqtt project. See http://www.zigbee2mqtt.io/how_tos/how_to_support_new_devices.html link. Maybe it could be a good idea to copy ideas from that guide to make a similar guide for how to create ZHA Device Handlers for Home Assistant?