### PR TITLE
Add support for Lutron Connected Bulb Remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Custom quirks implementations for zigpy implemented as ZHA Device Handlers are a
 - [Motion Sensor](http://a.co/65rSQjZ): MotionV4
 - [Multi Sensor](http://a.co/gez6SzW): MultiV4
 
+### Lutron
+- [Connected Bulb Remote](https://www.lutron.com/TechnicalDocumentLibrary/040421_Zigbee_Programming_Guide.pdf): Lutron LZL4BWHL01 Remote
+
 # Configuration:
 
 1. Update Home Assistant to 0.85.1 or a later version.
@@ -77,6 +80,9 @@ Custom quirks implementations for zigpy implemented as ZHA Device Handlers are a
 - All supported devices report battery level
 - tagV4 exposed as a device tracker in Home Assistant. The current implementation will use batteries rapidly
 - MultiV4 reports acceleration
+
+### Lutron
+- Connected bulb remote publishes events to Home Assistant
 
 ### Thanks
 

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -5,6 +5,7 @@ import pkgutil
 from zigpy.quirks import CustomCluster
 import zigpy.types as types
 from zigpy.util import ListenableMixin
+from zigpy.zdo import types as zdotypes
 
 UNKNOWN = 'Unknown'
 
@@ -55,6 +56,35 @@ class EventableCluster(CustomCluster):
                 'value': value
             }
         )
+
+
+class GroupBoundCluster(CustomCluster):
+    """
+    Cluster that can only bind to a group instead of direct to hub.
+
+    Binding this cluster results in binding to a group that the coordinator
+    is a member of.
+    """
+
+    COORDINATOR_GROUP_ID = 0x30  # Group id with only coordinator as a member
+
+    async def bind(self):
+        """Bind cluster to a group."""
+        # Ensure coordinator is a member of the group
+        application = self._endpoint.device.application
+        coordinator = application.get_device(application.ieee)
+        await coordinator.add_to_group(self.COORDINATOR_GROUP_ID)
+
+        # Bind cluster to group
+        dstaddr = zdotypes.MultiAddress()
+        dstaddr.addrmode = 1
+        dstaddr.nwk = self.COORDINATOR_GROUP_ID
+        dstaddr.endpoint = self._endpoint.endpoint_id
+        return await self._endpoint.device.zdo.Bind_req(
+            self._endpoint.device.ieee,
+            self._endpoint.endpoint_id,
+            self.cluster_id,
+            dstaddr)
 
 
 NAME = __name__

--- a/zhaquirks/lutron/__init__.py
+++ b/zhaquirks/lutron/__init__.py
@@ -1,0 +1,1 @@
+"""Module for Lutron devices."""

--- a/zhaquirks/lutron/lzl4bwhl01remote.py
+++ b/zhaquirks/lutron/lzl4bwhl01remote.py
@@ -1,0 +1,94 @@
+"""Device handler for Lutron LZL4BWHL01 Remote."""
+from zigpy.profiles import zll
+from zigpy.zcl.clusters.general import Basic, Identify, Groups, Scenes, OnOff,\
+    LevelControl
+from zigpy.zcl.clusters.lightlink import LightLink
+from zigpy.quirks import CustomDevice
+from zhaquirks import GroupBoundCluster
+
+
+MANUFACTURER_SPECIFIC_CLUSTER_ID_1 = 0xFF00  # decimal = 65280
+MANUFACTURER_SPECIFIC_CLUSTER_ID_2 = 0xFC44  # decimal = 64580
+
+
+class OnOffGroupCluster(GroupBoundCluster, OnOff):
+    """On/Off Cluster which only binds to a group."""
+
+    pass
+
+
+class LevelControlGroupCluster(GroupBoundCluster, LevelControl):
+    """Level Control Cluster which only binds to a group."""
+
+    pass
+
+
+class LutronLZL4BWHL01Remote(CustomDevice):
+    """Custom device representing Lutron LZL4BWHL01 Remote."""
+
+    signature = {
+        #  <SimpleDescriptor endpoint=1 profile=49246 device_type=2080
+        #  device_version=2
+        #  input_clusters=[0, 4096, 65280, 64580]
+        #  output_clusters=[4096, 3, 6, 8, 4, 5, 0, 65280]>
+        1: {
+            'model': 'LZL4BWHL01 Remote',
+            'manufacturer': 'Lutron',
+            'profile_id': zll.PROFILE_ID,
+            'device_type': zll.DeviceType.CONTROLLER,
+            'input_clusters': [
+                Basic.cluster_id,
+                LightLink.cluster_id,
+                MANUFACTURER_SPECIFIC_CLUSTER_ID_1,
+                MANUFACTURER_SPECIFIC_CLUSTER_ID_2
+            ],
+            'output_clusters': [
+                LightLink.cluster_id,
+                Identify.cluster_id,
+                OnOff.cluster_id,
+                LevelControl.cluster_id,
+                Groups.cluster_id,
+                Scenes.cluster_id,
+                Basic.cluster_id,
+                MANUFACTURER_SPECIFIC_CLUSTER_ID_1
+            ],
+        },
+    }
+
+    replacement = {
+        'endpoints': {
+            1: {
+                'manufacturer': 'Lutron',
+                'model': 'LZL4BWHL01 Remote',
+                'profile_id': zll.PROFILE_ID,
+                'device_type': zll.DeviceType.CONTROLLER,
+                'input_clusters': [
+                    Basic.cluster_id,
+                    LightLink.cluster_id,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID_1,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID_2
+                ],
+                'output_clusters': [
+                    LightLink.cluster_id,
+                    Identify.cluster_id,
+                    OnOffGroupCluster,
+                    LevelControlGroupCluster,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    Basic.cluster_id,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID_1
+                ],
+            }
+        },
+    }
+
+
+class LutronLZL4BWHL01Remote2(LutronLZL4BWHL01Remote):
+    """Custom device representing Lutron LZL4BWHL01 Remote."""
+
+    signature = {
+        1: {
+            **LutronLZL4BWHL01Remote.signature[1],
+            'manufacturer': ' Lutron',  # Some remotes report a leading space
+        }
+    }


### PR DESCRIPTION
Remote only supports binding to groups, not devices.
Add a global group id which is subscribed to by
the coordinator and used for receiving broadcasts
from the device.

Fixes #32 