### PR TITLE
XBee: support for serial data communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ Custom quirks implementations for zigpy implemented as ZHA Device Handlers are a
 ### Lutron
 - [Connected Bulb Remote](https://www.lutron.com/TechnicalDocumentLibrary/040421_Zigbee_Programming_Guide.pdf): Lutron LZL4BWHL01 Remote
 
+### Digi
+- [XBee Series 2](https://www.digi.com/products/embedded-systems/rf-modules/2-4-ghz-modules/xbee-zigbee): xbee
+- [XBee Series 3](https://www.digi.com/products/embedded-systems/rf-modules/2-4-ghz-modules/xbee3-zigbee-3): xbee3
+
 # Configuration:
 
 1. Update Home Assistant to 0.85.1 or a later version.
@@ -82,7 +86,38 @@ Custom quirks implementations for zigpy implemented as ZHA Device Handlers are a
 - MultiV4 reports acceleration
 
 ### Lutron
+
 - Connected bulb remote publishes events to Home Assistant
+
+### Digi XBee
+
+- Some functionality requires a coordinator device to be XBee as well
+- GPIO pins are exposed to Home Assistant as switches
+- Outgoing UART data can be sent with `zha.issue_zigbee_cluster_command` service
+- Incoming UART data will generate `zha_event` event.
+
+For example, the following script replies with an `Assistant` string to the device once it receives a `Home` string from it (replace ieee with your actual endpoint device ieee):
+```
+automation:
+  - alias: XBee UART Test
+    trigger:
+      platform: event
+      event_type: zha_event
+      event_data:
+        device_ieee: 00:13:a2:00:12:34:56:78
+        command: receive_data
+        args: Home
+    action:
+      service: zha.issue_zigbee_cluster_command
+      data:
+        ieee: 00:13:a2:00:12:34:56:78
+        endpoint_id: 232
+        cluster_id: 17
+        cluster_type: in
+        command: 0
+        command_type: server
+        args: Assistant
+```
 
 ### Thanks
 

--- a/zhaquirks/xbee/xbee3_io.py
+++ b/zhaquirks/xbee/xbee3_io.py
@@ -19,14 +19,16 @@ import struct
 import zigpy.types as t
 from zigpy.quirks import CustomDevice, CustomCluster
 from zigpy.profiles import zha
-from zigpy.zcl.clusters.general import OnOff, BinaryInput
+from zigpy.zcl.clusters.general import OnOff, BinaryInput, LevelControl
 
 from zigpy.zcl import foundation
+from zhaquirks import EventableCluster, LocalDataCluster
 
 _LOGGER = logging.getLogger(__name__)
 
 XBEE_PROFILE_ID = 0xC105
 XBEE_IO_CLUSTER = 0x92
+XBEE_DATA_CLUSTER = 0x11
 XBEE_REMOTE_AT = 0x17
 XBEE_SRC_ENDPOINT = 0xe8
 XBEE_DST_ENDPOINT = 0xe8
@@ -34,6 +36,7 @@ DIO_APPLY_CHANGES = 0x02
 DIO_PIN_HIGH = 0x05
 DIO_PIN_LOW = 0x04
 ON_OFF_CMD = 0x0000
+DATA_IN_CMD = 0x0000
 
 
 class IOSample(bytes):
@@ -231,6 +234,65 @@ class XBee3Sensor(CustomDevice):
             0x0000: ('io_sample', (IOSample,), False),
         }
 
+    class EventRelayCluster(EventableCluster, LevelControl):
+        """A cluster with cluster_id which is allowed to send events."""
+
+        attributes = {}
+        client_commands = {}
+        server_commands = {
+            0x0000: ('receive_data', (str,), None),
+        }
+
+    class SerialDataCluster(LocalDataCluster):
+        """Serial Data Cluster for the XBee."""
+
+        cluster_id = XBEE_DATA_CLUSTER
+
+        def command(self, command, *args,
+                    manufacturer=None, expect_reply=False):
+            """Handle outgoing data."""
+            data = bytes(''.join(args), encoding='latin1')
+            return self._endpoint.device.application.request(
+                self._endpoint.device.nwk,
+                XBEE_PROFILE_ID,
+                XBEE_DATA_CLUSTER,
+                XBEE_SRC_ENDPOINT,
+                XBEE_DST_ENDPOINT,
+                self._endpoint.device.application.get_sequence(),
+                data,
+                expect_reply=False
+            )
+
+        def handle_cluster_request(self, tsn, command_id, args):
+            """Handle incoming data."""
+            if command_id == DATA_IN_CMD:
+                self._endpoint.out_clusters[
+                    LevelControl.cluster_id].handle_cluster_request(
+                        tsn,
+                        command_id,
+                        str(args, encoding='latin1')
+                    )
+            else:
+                super().handle_cluster_request(tsn, command_id, args)
+
+        attributes = {}
+        client_commands = {
+            0x0000: ('send_data', (bytes,), None),
+        }
+        server_commands = {
+            0x0000: ('receive_data', (bytes,), None),
+        }
+
+    def deserialize(self, endpoint_id, cluster_id, data):
+        """Pretends to be parsing incoming data."""
+        if cluster_id != XBEE_DATA_CLUSTER:
+            return super().deserialize(endpoint_id, cluster_id, data)
+
+        tsn = self._application.get_sequence()
+        command_id = DATA_IN_CMD + 256
+        is_reply = False
+        return tsn, command_id, is_reply, data
+
     signature = {
         232: {
             'profile_id': XBEE_PROFILE_ID,
@@ -256,8 +318,11 @@ class XBee3Sensor(CustomDevice):
                 'model': 'xbee.io',
                 'input_clusters': [
                     DigitalIOCluster,
+                    SerialDataCluster,
                 ],
                 'output_clusters': [
+                    SerialDataCluster,
+                    EventRelayCluster,
                 ],
             },
             0xd0: {


### PR DESCRIPTION
XBee devices can work as transparent UART relay: any data sent to one device is written by another.
This patch adds support for two-way communication of arbitrary UART serial data between two XBee devices (both coordinator and endpoint device must be XBee). This could be used to control a wide number of devices such as TOSR0X relays.

To send the data, use the zha.issue_zigbee_cluster_command service, i.e.
```
service: zha.issue_zigbee_cluster_command
            data:
              ieee: 00:13:a2:00:40:f5:2a:be
              endpoint_id: 232
              cluster_id: 17
              cluster_type: in
              command: 0
              command_type: server
              args: Hello World
```

To receive the data, subscribe to the following event:
```
{
    "event_type": "zha_event",
    "data": {
        "unique_id": "0x4ba1:232:0x0008",
        "device_ieee": "00:13:a2:00:40:f5:2a:be",
        "command": "receive_data",
        "args": "27.00\r\n"
    },
    "origin": "LOCAL",
    "time_fired": "2019-06-07T22:33:27.721934+00:00",
    "context": {
        "id": "c72f7676c0f74316bffac1769cc4f241",
        "parent_id": null,
        "user_id": null
    }
}
```