### PR TITLE
Fix xiaomi aqara to not report bogus temperature values

### DIFF
--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -6,7 +6,9 @@ import logging
 from zigpy.quirks import CustomCluster, CustomDevice
 from zigpy import types as t
 from zigpy.zcl.clusters.general import Basic, PowerConfiguration
-from zigpy.zcl.clusters.measurement import OccupancySensing
+from zigpy.zcl.clusters.measurement import (
+    OccupancySensing, TemperatureMeasurement
+)
 from zigpy.zcl.clusters.security import IasZone
 import zigpy.zcl.foundation as foundation
 
@@ -269,3 +271,15 @@ class MotionCluster(LocalDataCluster, IasZone):
             ZONE_STATE,
             [OFF]
         )
+
+
+class TemperatureMeasurementCluster(CustomCluster, TemperatureMeasurement):
+    """Temperature cluster that filters out invalid temperature readings."""
+
+    cluster_id = TemperatureMeasurement.cluster_id
+
+    def _update_attribute(self, attrid, value):
+        # drop values above and below documented range for this sensor
+        # value is in centi degrees
+        if attrid == 0 and (value >= -2000 or value <= 6000):
+            super()._update_attribute(attrid, value)

--- a/zhaquirks/xiaomi/aqara/__init__.py
+++ b/zhaquirks/xiaomi/aqara/__init__.py
@@ -1,6 +1,7 @@
 """Module for Xiaomi Aqara quirks implementations."""
 import math
-from zigpy.zcl.clusters.measurement import (IlluminanceMeasurement, TemperatureMeasurement)
+from zigpy.zcl.clusters.measurement import (IlluminanceMeasurement,
+    TemperatureMeasurement)
 from zhaquirks import CustomCluster
 
 
@@ -17,7 +18,8 @@ class IlluminanceMeasurementCluster(CustomCluster, IlluminanceMeasurement):
 
 class TemperatureMeasurementCluster(CustomCluster, TemperatureMeasurement):
     """Temperature input cluster that restricts values to filter out bogus
-    values."""
+    values.
+    """
 
     cluster_id = TemperatureMeasurement.cluster_id
 

--- a/zhaquirks/xiaomi/aqara/__init__.py
+++ b/zhaquirks/xiaomi/aqara/__init__.py
@@ -1,6 +1,6 @@
 """Module for Xiaomi Aqara quirks implementations."""
 import math
-from zigpy.zcl.clusters.measurement import IlluminanceMeasurement
+from zigpy.zcl.clusters.measurement import (IlluminanceMeasurement, TemperatureMeasurement)
 from zhaquirks import CustomCluster
 
 
@@ -13,3 +13,16 @@ class IlluminanceMeasurementCluster(CustomCluster, IlluminanceMeasurement):
         if attrid == 0 and value > 0:
             value = 10000 * math.log10(value) + 1
         super()._update_attribute(attrid, value)
+
+
+class TemperatureMeasurementCluster(CustomCluster, TemperatureMeasurement):
+    """Temperature input cluster that restricts values to filter out bogus
+    values."""
+
+    cluster_id = TemperatureMeasurement.cluster_id
+
+    def _update_attribute(self, attrid, value):
+        # drop values above and below documented range for this sensor
+        # value is in centi degrees
+        if attrid == 0 and (value >= -2000 or value <= 6000):
+            super()._update_attribute(attrid, value)

--- a/zhaquirks/xiaomi/aqara/__init__.py
+++ b/zhaquirks/xiaomi/aqara/__init__.py
@@ -1,7 +1,6 @@
 """Module for Xiaomi Aqara quirks implementations."""
 import math
-from zigpy.zcl.clusters.measurement import (
-    IlluminanceMeasurement, TemperatureMeasurement)
+from zigpy.zcl.clusters.measurement import IlluminanceMeasurement
 from zhaquirks import CustomCluster
 
 
@@ -14,15 +13,3 @@ class IlluminanceMeasurementCluster(CustomCluster, IlluminanceMeasurement):
         if attrid == 0 and value > 0:
             value = 10000 * math.log10(value) + 1
         super()._update_attribute(attrid, value)
-
-
-class TemperatureMeasurementCluster(CustomCluster, TemperatureMeasurement):
-    """Temperature cluster that filters out invalid temperature readings."""
-
-    cluster_id = TemperatureMeasurement.cluster_id
-
-    def _update_attribute(self, attrid, value):
-        # drop values above and below documented range for this sensor
-        # value is in centi degrees
-        if attrid == 0 and (value >= -2000 or value <= 6000):
-            super()._update_attribute(attrid, value)

--- a/zhaquirks/xiaomi/aqara/__init__.py
+++ b/zhaquirks/xiaomi/aqara/__init__.py
@@ -17,9 +17,7 @@ class IlluminanceMeasurementCluster(CustomCluster, IlluminanceMeasurement):
 
 
 class TemperatureMeasurementCluster(CustomCluster, TemperatureMeasurement):
-    """Temperature input cluster that restricts values to filter out bogus
-    values.
-    """
+    """Temperature cluster that filters out invalid temperature readings."""
 
     cluster_id = TemperatureMeasurement.cluster_id
 

--- a/zhaquirks/xiaomi/aqara/__init__.py
+++ b/zhaquirks/xiaomi/aqara/__init__.py
@@ -1,7 +1,7 @@
 """Module for Xiaomi Aqara quirks implementations."""
 import math
-from zigpy.zcl.clusters.measurement import (IlluminanceMeasurement,
-    TemperatureMeasurement)
+from zigpy.zcl.clusters.measurement import (
+    IlluminanceMeasurement, TemperatureMeasurement)
 from zhaquirks import CustomCluster
 
 

--- a/zhaquirks/xiaomi/aqara/weather.py
+++ b/zhaquirks/xiaomi/aqara/weather.py
@@ -11,7 +11,7 @@ from zigpy.zcl.clusters.measurement import (
 from zhaquirks.xiaomi import (
     BasicCluster, PowerConfigurationCluster, XiaomiCustomDevice)
 
-from . import TemperatureMeasurementCluster
+from .. import TemperatureMeasurementCluster
 
 TEMPERATURE_HUMIDITY_DEVICE_TYPE = 0x5F01
 XIAOMI_CLUSTER_ID = 0xFFFF

--- a/zhaquirks/xiaomi/aqara/weather.py
+++ b/zhaquirks/xiaomi/aqara/weather.py
@@ -5,11 +5,12 @@ from zigpy import quirks
 from zigpy.profiles import zha
 from zigpy.quirks.xiaomi import AqaraTemperatureHumiditySensor
 from zigpy.zcl.clusters.general import Groups, Identify
-from zigpy.zcl.clusters.measurement import (
-    PressureMeasurement, RelativeHumidity, TemperatureMeasurement)
+from zigpy.zcl.clusters.measurement import PressureMeasurement, RelativeHumidity
 
 from zhaquirks.xiaomi import (
     BasicCluster, PowerConfigurationCluster, XiaomiCustomDevice)
+
+from . import TemperatureMeasurementCluster
 
 TEMPERATURE_HUMIDITY_DEVICE_TYPE = 0x5F01
 XIAOMI_CLUSTER_ID = 0xFFFF
@@ -40,7 +41,7 @@ class Weather(XiaomiCustomDevice):
                     BasicCluster.cluster_id,
                     Identify.cluster_id,
                     XIAOMI_CLUSTER_ID,
-                    TemperatureMeasurement.cluster_id,
+                    TemperatureMeasurementCluster.cluster_id,
                     PressureMeasurement.cluster_id,
                     RelativeHumidity.cluster_id
                 ],
@@ -60,7 +61,7 @@ class Weather(XiaomiCustomDevice):
                     BasicCluster,
                     PowerConfigurationCluster,
                     Identify.cluster_id,
-                    TemperatureMeasurement.cluster_id,
+                    TemperatureMeasurementCluster,
                     PressureMeasurement.cluster_id,
                     RelativeHumidity.cluster_id,
                     XIAOMI_CLUSTER_ID

--- a/zhaquirks/xiaomi/aqara/weather.py
+++ b/zhaquirks/xiaomi/aqara/weather.py
@@ -5,8 +5,8 @@ from zigpy import quirks
 from zigpy.profiles import zha
 from zigpy.quirks.xiaomi import AqaraTemperatureHumiditySensor
 from zigpy.zcl.clusters.general import Groups, Identify
-from zigpy.zcl.clusters.measurement import (PressureMeasurement,
-    RelativeHumidity)
+from zigpy.zcl.clusters.measurement import (
+    PressureMeasurement, RelativeHumidity)
 
 from zhaquirks.xiaomi import (
     BasicCluster, PowerConfigurationCluster, XiaomiCustomDevice)

--- a/zhaquirks/xiaomi/aqara/weather.py
+++ b/zhaquirks/xiaomi/aqara/weather.py
@@ -5,7 +5,8 @@ from zigpy import quirks
 from zigpy.profiles import zha
 from zigpy.quirks.xiaomi import AqaraTemperatureHumiditySensor
 from zigpy.zcl.clusters.general import Groups, Identify
-from zigpy.zcl.clusters.measurement import PressureMeasurement, RelativeHumidity
+from zigpy.zcl.clusters.measurement import (PressureMeasurement,
+    RelativeHumidity)
 
 from zhaquirks.xiaomi import (
     BasicCluster, PowerConfigurationCluster, XiaomiCustomDevice)

--- a/zhaquirks/xiaomi/mija/sensor_ht.py
+++ b/zhaquirks/xiaomi/mija/sensor_ht.py
@@ -6,11 +6,12 @@ from zigpy.profiles import zha
 from zigpy.quirks.xiaomi import TemperatureHumiditySensor
 from zigpy.zcl.clusters.general import (
     AnalogInput, Groups, Identify, MultistateInput, Ota, Scenes)
-from zigpy.zcl.clusters.measurement import (
-    RelativeHumidity, TemperatureMeasurement)
+from zigpy.zcl.clusters.measurement import RelativeHumidity
 
 from zhaquirks.xiaomi import (
     BasicCluster, PowerConfigurationCluster, XiaomiCustomDevice)
+
+from .. import TemperatureMeasurementCluster
 
 TEMPERATURE_HUMIDITY_DEVICE_TYPE = 0x5F01
 TEMPERATURE_HUMIDITY_DEVICE_TYPE2 = 0x5F02
@@ -104,7 +105,7 @@ class Weather(XiaomiCustomDevice):
                     BasicCluster,
                     PowerConfigurationCluster,
                     Identify.cluster_id,
-                    TemperatureMeasurement.cluster_id,
+                    TemperatureMeasurementCluster,
                     RelativeHumidity.cluster_id,
                     XIAOMI_CLUSTER_ID,
                     Ota.cluster_id


### PR DESCRIPTION
Xiaomi Aqara Weather sensors sometimes report temperature of -100°C. This PR caps temperature reports at the documented temperature range for this sensor.

https://xiaomi-mi.com/sockets-and-sensors/aqara-temperature-and-humidity-sensor/

So far I could test that the sensor still works but I do not find a way to provoke this bogus report from one of my sensors.