### PR TITLE
Add support for additional Xiaomi switch models

### DIFF
--- a/zhaquirks/xiaomi/aqara/remote_b186acn01.py
+++ b/zhaquirks/xiaomi/aqara/remote_b186acn01.py
@@ -65,7 +65,8 @@ class RemoteB186ACN01(XiaomiCustomDevice):
         # input_clusters=[0, 3, 25, 65535, 18]
         # output_clusters=[0, 4, 3, 5, 25, 65535, 18]>
         'models_info': [
-            ('LUMI', 'lumi.remote.b186acn01')
+            ('LUMI', 'lumi.remote.b186acn01'),
+            ('LUMI', 'lumi.sensor_86sw1')
         ],
         'endpoints': {
             1: {

--- a/zhaquirks/xiaomi/aqara/remote_b286acn01.py
+++ b/zhaquirks/xiaomi/aqara/remote_b286acn01.py
@@ -74,7 +74,8 @@ class RemoteB286ACN01(XiaomiCustomDevice):
         # input_clusters=[0, 3, 25, 65535, 18]
         # output_clusters=[0, 4, 3, 5, 25, 65535, 18]>
         'models_info': [
-            ('LUMI', 'lumi.remote.b286acn01')
+            ('LUMI', 'lumi.remote.b286acn01'),
+            ('LUMI', 'lumi.sensor_86sw2')
         ],
         'endpoints': {
             1: {


### PR DESCRIPTION
This PR adds support for lumi.sensor_86sw1 and lumi.sensor_86sw2 switches.