### PR TITLE
Correct attribute dictionaries

### DIFF
--- a/zhaquirks/philips/rwl021.py
+++ b/zhaquirks/philips/rwl021.py
@@ -15,6 +15,7 @@ class BasicCluster(CustomCluster, Basic):
     def __init__(self, *args, **kwargs):
         """Init."""
         super().__init__(*args, **kwargs)
+        self.attributes = super().attributes.copy()
         self.attributes.update({
             0x0031: ('phillips', t.bitmap16),
         })

--- a/zhaquirks/sinope/thermostat.py
+++ b/zhaquirks/sinope/thermostat.py
@@ -46,7 +46,7 @@ class SinopeTechnologiesThermostat(CustomDevice):
         def __init__(self, *args, **kwargs):
             """Init method."""
             super().__init__(*args, **kwargs)
-            self.attributes = Thermostat.attributes
+            self.attributes = Thermostat.attributes.copy()
             self.attributes[0x0400] = ('set_occupancy', t.enum8)
             self._attridx = {
                 attrname: attrid for attrid, (attrname, datatype)

--- a/zhaquirks/xiaomi/aqara/vibration_aq1.py
+++ b/zhaquirks/xiaomi/aqara/vibration_aq1.py
@@ -50,6 +50,7 @@ class VibrationAQ1(XiaomiCustomDevice):
         def __init__(self, *args, **kwargs):
             """Init."""
             super().__init__(*args, **kwargs)
+            self.attributes = super().attributes.copy()
             self.attributes.update({
                 0xFF0D: ('sensitivity', types.uint8_t),
             })
@@ -63,6 +64,7 @@ class VibrationAQ1(XiaomiCustomDevice):
             """Init."""
             self._current_state = {}
             super().__init__(*args, **kwargs)
+            self.attributes = super().attributes.copy()
             self.attributes.update({
                 0x0000: ('lock_state', types.uint8_t),
             })


### PR DESCRIPTION
We were modifying the parent class dictionaries causing all implementations and instances to contain the modifications from the quirks. 