### PR TITLE
Add Centralite 3157100 thermostat quirks

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Custom quirks implementations for zigpy implemented as ZHA Device Handlers are a
 - [Motion Sensor](https://www.irisbylowes.com/support/?guideTitle=Iris-Motion-Sensor&guideId=4be71b61-5938-30b6-8154-bd90cb9b4796): CentraLite 3326-L
 - [Contact Sensor](http://a.co/9PCEorM): CentraLite 3321-S
 - [Temperature / Humidity Sensor](https://bit.ly/2GYguGR): CentraLite 3310-S
+- [Thermostat](https://centralite.com/products/pearl-thermostat): CentraLite 3157100
 
 ### Xiaomi Aqara
 - [Cube](https://www.aqara.com/en/cube_controller-product.html): lumi.sensor_cube.aqgl01

--- a/pylintrc
+++ b/pylintrc
@@ -50,7 +50,7 @@ expected-line-ending-format=LF
 overgeneral-exceptions=Exception
 
 [BASIC]
-good-names=3321S, 3130, 3300S, 3310S, 3305S, mot003V0, mot003V6
+good-names=3321S, 3130, 3300S, 3310S, 3305S, 3157100, mot003V0, mot003V6
 
 [CLASSES]
 exclude-protected=_DEVICE_REGISTRY

--- a/zhaquirks/centralite/3157100.py
+++ b/zhaquirks/centralite/3157100.py
@@ -1,0 +1,69 @@
+"""Device handler for centralite 3157100."""
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.general import (
+    Basic, Identify, Ota, Time, PollControl)
+from zigpy.zcl.clusters.hvac import (
+    Fan, Thermostat, UserInterface)
+
+from zhaquirks.centralite import PowerConfigurationCluster
+
+DIAGNOSTICS_CLUSTER_ID = 0x0B05  # decimal = 2821
+
+
+class CentraLite3157100(CustomDevice):
+    """Custom device representing centralite 3157100."""
+
+    signature = {
+        #  <SimpleDescriptor endpoint=1 profile=260 device_type=769
+        #  device_version=0
+        #  input_clusters=[0, 1, 3, 513, 514, 516, 32, 2821]
+        #  output_clusters=[10, 25]>
+
+        'models_info': [
+            ('Centralite', '3157100')
+        ],
+        'endpoints': {
+            1: {
+                'profile_id': zha.PROFILE_ID,
+                'device_type': zha.DeviceType.THERMOSTAT,
+                'input_clusters': [
+                    Basic.cluster_id,
+                    PowerConfigurationCluster.cluster_id,
+                    Identify.cluster_id,
+                    Thermostat.cluster_id,
+                    Fan.cluster_id,
+                    UserInterface.cluster_id,
+                    PollControl.cluster_id,
+                    DIAGNOSTICS_CLUSTER_ID
+                ],
+                'output_clusters': [
+                    Time.cluster_id,
+                    Ota.cluster_id
+                ],
+            },
+        }
+    }
+
+    replacement = {
+        'endpoints': {
+            1: {
+                'profile_id': zha.PROFILE_ID,
+                'device_type': zha.DeviceType.THERMOSTAT,
+                'input_clusters': [
+                    Basic.cluster_id,
+                    PowerConfigurationCluster,
+                    Identify.cluster_id,
+                    Thermostat.cluster_id,
+                    Fan.cluster_id,
+                    UserInterface.cluster_id,
+                    PollControl.cluster_id,
+                    DIAGNOSTICS_CLUSTER_ID
+                ],
+                'output_clusters': [
+                    Time.cluster_id,
+                    Ota.cluster_id
+                ],
+            },
+        },
+    }


### PR DESCRIPTION
This thermostat does not report battery_percentage_remaining,
like most other Centralite devices.
Use the existing code to convert from battery_voltage.