### PR TITLE
Modify Centralite 3305S quirk to support single endpoint devices

### DIFF
--- a/zhaquirks/centralite/3305S.py
+++ b/zhaquirks/centralite/3305S.py
@@ -102,6 +102,9 @@ class CentraLite3305S2(CentraLite3305S):
     """Custom device representing centralite 3305 with one endpoint."""
 
     signature = {
+        'models_info': [
+            ('CentraLite', '3305'),
+        ],
         'endpoints': {
             1: {
                 **CentraLite3305S.signature['endpoints'][1]

--- a/zhaquirks/centralite/3305S.py
+++ b/zhaquirks/centralite/3305S.py
@@ -96,3 +96,23 @@ class CentraLite3305S(CustomDevice):
             }
         },
     }
+
+
+class CentraLite3305S2(CentraLite3305S):
+    """Custom device representing centralite 3305 with one endpoint."""
+
+    signature = {
+        'endpoints': {
+            1: {
+                **CentraLite3305S.signature['endpoints'][1]
+            }
+        }
+    }
+
+    replacement = {
+        'endpoints': {
+            1: {
+                **CentraLite3305S.replacement['endpoints'][1]
+            }
+        }
+    }


### PR DESCRIPTION
My PEQ motion sensor (Centralite 3305) only has one endpoint,
so it doesn't match the existing signature.  Add another object
with only one endpoint so it will match.