### PR TITLE
Add Centralite 3460-L smart button quirk

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Custom quirks implementations for zigpy implemented as ZHA Device Handlers are a
 - [Motion Sensor](https://www.irisbylowes.com/support/?guideTitle=Iris-Motion-Sensor&guideId=4be71b61-5938-30b6-8154-bd90cb9b4796): CentraLite 3326-L
 - [Contact Sensor](http://a.co/9PCEorM): CentraLite 3321-S
 - [Temperature / Humidity Sensor](https://bit.ly/2GYguGR): CentraLite 3310-S
+- [Smart Button](http://pdf.lowes.com/useandcareguides/812489023018_use.pdf): CentraLite 3340-L
 
 ### Xiaomi Aqara
 - [Cube](https://www.aqara.com/en/cube_controller-product.html): lumi.sensor_cube.aqgl01

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Custom quirks implementations for zigpy implemented as ZHA Device Handlers are a
 - [Motion Sensor](https://www.irisbylowes.com/support/?guideTitle=Iris-Motion-Sensor&guideId=4be71b61-5938-30b6-8154-bd90cb9b4796): CentraLite 3326-L
 - [Contact Sensor](http://a.co/9PCEorM): CentraLite 3321-S
 - [Temperature / Humidity Sensor](https://bit.ly/2GYguGR): CentraLite 3310-S
-- [Smart Button](http://pdf.lowes.com/useandcareguides/812489023018_use.pdf): CentraLite 3340-L
+- [Smart Button](http://pdf.lowes.com/useandcareguides/812489023018_use.pdf): CentraLite 3460-L
 
 ### Xiaomi Aqara
 - [Cube](https://www.aqara.com/en/cube_controller-product.html): lumi.sensor_cube.aqgl01

--- a/pylintrc
+++ b/pylintrc
@@ -50,7 +50,7 @@ expected-line-ending-format=LF
 overgeneral-exceptions=Exception
 
 [BASIC]
-good-names=3321S, 3130, 3300S, 3310S, 3305S, mot003V0, mot003V6
+good-names=3321S, 3130, 3300S, 3310S, 3305S, 3460L, mot003V0, mot003V6
 
 [CLASSES]
 exclude-protected=_DEVICE_REGISTRY

--- a/zhaquirks/centralite/3460L.py
+++ b/zhaquirks/centralite/3460L.py
@@ -1,0 +1,66 @@
+"""Device handler for centralite 3460L."""
+# pylint disable=C0103
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.general import (
+    Basic, Identify, OnOff, OnOffConfiguration, Ota, PollControl)
+from zigpy.zcl.clusters.measurement import TemperatureMeasurement
+
+from zhaquirks.centralite import PowerConfigurationCluster
+
+DIAGNOSTICS_CLUSTER_ID = 0x0B05  # decimal = 2821
+
+
+class CentraLite3460L(CustomDevice):
+    """Custom device representing centralite 3460L."""
+
+    signature = {
+        #  <SimpleDescriptor endpoint=1 profile=260 device_type=6
+        #  device_version=0
+        #  input_clusters=[0, 1, 3, 7, 32, 1026, 2821]
+        #  output_clusters=[3, 6, 25]>
+        'models_info': [
+            ('CentraLite', '3460-L')
+        ],
+        'endpoints': {
+            1: {
+                'profile_id': zha.PROFILE_ID,
+                'device_type': zha.DeviceType.REMOTE_CONTROL,
+                'input_clusters': [
+                    Basic.cluster_id,
+                    PowerConfigurationCluster.cluster_id,
+                    Identify.cluster_id,
+                    OnOffConfiguration.cluster_id,
+                    PollControl.cluster_id,
+                    TemperatureMeasurement.cluster_id,
+                    DIAGNOSTICS_CLUSTER_ID
+                ],
+                'output_clusters': [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    Ota.cluster_id
+                ],
+            },
+        }
+    }
+
+    replacement = {
+        'endpoints': {
+            1: {
+                'input_clusters': [
+                    Basic.cluster_id,
+                    PowerConfigurationCluster,
+                    Identify.cluster_id,
+                    OnOffConfiguration.cluster_id,
+                    PollControl.cluster_id,
+                    TemperatureMeasurement.cluster_id,
+                    DIAGNOSTICS_CLUSTER_ID
+                ],
+                'output_clusters': [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    Ota.cluster_id
+                ],
+            }
+        },
+    }


### PR DESCRIPTION
This button does not report battery_percentage_remaining,
like most other Centralite devices.
Use the existing code to convert from battery_voltage.