### PR TITLE
Add secondary Waxman LeakSmart class without PollControl cluster for sensors that don't support it.

### DIFF
--- a/zhaquirks/waxman/leaksmart.py
+++ b/zhaquirks/waxman/leaksmart.py
@@ -131,3 +131,60 @@ class WAXMANleakSMARTv2(CustomDevice):
             },
         }
     }
+
+class WAXMANleakSMARTv2_2(CustomDevice):
+    """Custom device representing WAXMAN leakSMART v2 without PollControl cluster"""
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        self.ias_bus = Bus()
+        super().__init__(*args, **kwargs)
+
+    signature = {
+        #  <SimpleDescriptor endpoint=1 profile=260 device_type=770
+        #  device_version=0
+        #  input_clusters=[0, 1, 3, 1026, 2818, 64514]
+        #  output_clusters=[3, 25]>
+        'models_info': [
+            ('WAXMAN', 'leakSMART Water Sensor V2'),
+        ],
+        'endpoints': {
+            1: {
+                'profile_id': zha.PROFILE_ID,
+                'device_type': zha.DeviceType.TEMPERATURE_SENSOR,
+                'input_clusters': [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    TemperatureMeasurement.cluster_id,
+                    ApplianceEventAlerts.cluster_id,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID
+                ],
+                'output_clusters': [
+                    Identify.cluster_id,
+                    Ota.cluster_id
+                ],
+            },
+        }
+    }
+
+    replacement = {
+        'endpoints': {
+            1: {
+                'profile_id': zha.PROFILE_ID,
+                'device_type': zha.DeviceType.TEMPERATURE_SENSOR,
+                'input_clusters': [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    TemperatureMeasurement.cluster_id,
+                    WAXMANApplianceEventAlerts,
+                    EmulatedIasZone
+                ],
+                'output_clusters': [
+                    Identify.cluster_id,
+                    Ota.cluster_id
+                ],
+            },
+        }
+    }

--- a/zhaquirks/waxman/leaksmart.py
+++ b/zhaquirks/waxman/leaksmart.py
@@ -134,8 +134,9 @@ class WAXMANleakSMARTv2(CustomDevice):
 
 
 class WAXMANleakSMARTv2NOPOLL(CustomDevice):
-    """Custom device representing WAXMAN leakSMART v2 
-       without PollControl cluster."""
+    """Custom device representing WAXMAN leakSMART v2
+    without PollControl cluster.
+    """
 
     def __init__(self, *args, **kwargs):
         """Init."""

--- a/zhaquirks/waxman/leaksmart.py
+++ b/zhaquirks/waxman/leaksmart.py
@@ -132,8 +132,10 @@ class WAXMANleakSMARTv2(CustomDevice):
         }
     }
 
-class WAXMANleakSMARTv2_2(CustomDevice):
-    """Custom device representing WAXMAN leakSMART v2 without PollControl cluster"""
+
+class WAXMANleakSMARTv2NOPOLL(CustomDevice):
+    """Custom device representing WAXMAN leakSMART v2 
+       without PollControl cluster."""
 
     def __init__(self, *args, **kwargs):
         """Init."""

--- a/zhaquirks/waxman/leaksmart.py
+++ b/zhaquirks/waxman/leaksmart.py
@@ -134,9 +134,7 @@ class WAXMANleakSMARTv2(CustomDevice):
 
 
 class WAXMANleakSMARTv2NOPOLL(CustomDevice):
-    """Custom device representing WAXMAN leakSMART v2
-    without PollControl cluster.
-    """
+    """Custom WAXMAN leakSMART v2 without PollControl cluster."""
 
     def __init__(self, *args, **kwargs):
         """Init."""


### PR DESCRIPTION
This adds a secondary LeakSmart class in the quirk to support sensor models without the PollControl cluster.