### PR TITLE
Add 2019 refresh of Samjin Multi

### DIFF
--- a/zhaquirks/samjin/multi2.py
+++ b/zhaquirks/samjin/multi2.py
@@ -1,0 +1,64 @@
+"""Samjin Multi 2019 Refresh Quirk."""
+from zigpy.quirks import CustomDevice
+from zigpy.quirks.smartthings import SmartThingsAccelCluster
+from zigpy.zcl.clusters.general import (
+    Basic, Identify, Ota, PollControl, PowerConfiguration)
+from zigpy.zcl.clusters.measurement import TemperatureMeasurement
+from zigpy.zcl.clusters.security import IasZone
+
+DIAGNOSTICS_CLUSTER_ID = 0x0B05  # decimal = 2821
+
+
+class SmartthingsMultiPurposeSensor2019(CustomDevice):
+    """Samjin multi device."""
+
+    signature = {
+        'models_info': [
+            ('Samjin', 'multi')
+        ],
+        'endpoints': {
+            # <SimpleDescriptor endpoint=1 profile=260 device_type=1026
+            # device_version=0 input_clusters=[0, 1, 3, 32, 1026, 1280,
+            # 2821, 64514]
+            # output_clusters=[3, 25]>
+            1: {
+                'profile_id': 0x0104,
+                'device_type': 0x0402,
+                'input_clusters': [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    PollControl.cluster_id,
+                    TemperatureMeasurement.cluster_id,
+                    IasZone.cluster_id,
+                    DIAGNOSTICS_CLUSTER_ID,
+                    SmartThingsAccelCluster.cluster_id
+                ],
+                'output_clusters': [
+                    Identify.cluster_id,
+                    Ota.cluster_id
+                ],
+            }
+        }
+    }
+
+    replacement = {
+        'endpoints': {
+            1: {
+                'input_clusters': [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    PollControl.cluster_id,
+                    TemperatureMeasurement.cluster_id,
+                    IasZone.cluster_id,
+                    DIAGNOSTICS_CLUSTER_ID,
+                    SmartThingsAccelCluster
+                ],
+                'output_clusters': [
+                    Identify.cluster_id,
+                    Ota.cluster_id
+                ],
+            }
+        }
+    }


### PR DESCRIPTION
Opening here instead of https://github.com/zigpy/zigpy/pull/228 per @Adminiuga's request.

I am not sure precisely what the `IasZone` cluster is used for here as I've not delved into Zigbee much. Seems like open/close perhaps? It seems to work properly without an additional handler in zigpy#228 above, so I figured there wasn't a need to refactor the `IASCluster` out of `button.py` as it seems that's used to make an open/close sensor appear as a button or some such? Might be worth a refactor there eventually as it seems that `IASCluster` is used for both buttons.

Does this all look correct? Here's the log output for this device refresh:

```
[0x00ea:1] Discovered endpoint information: <SimpleDescriptor endpoint=1 profile=260 device_type=1026 device_version=0 input_clusters=[0, 1, 3, 32, 1026, 1280, 2821, 64514] output_clusters=[3, 25]>
[0x00ea:1] Manufacturer: Samjin
[0x00ea:1] Model: multi
```

Seems it's just an added diagnostics cluster in the newer Samjin devices, looking at the button quirk. Note that there is another Samjin multi implementation in the `zigpy` repo in the file modified by the above linked PR for the 2018 version of this device that does not have the diagnostics cluster, perhaps it should be moved over here into `multi.py` which is currently empty other than a comment? I feel that should probably be a separate PR if so.

Cheers!
James