### PR TITLE
Fix Xiaomi sensors battery level

### DIFF
--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -186,8 +186,10 @@ class BasicCluster(CustomCluster, Basic):
     @staticmethod
     def _calculate_remaining_battery_percentage(voltage):
         """Calculate percentage."""
-        min_voltage = 2500
-        max_voltage = 3000
+        
+        # Min/Max values from https://github.com/louisZL/lumi-gateway-local-api
+        min_voltage = 2800
+        max_voltage = 3300
         percent = (voltage - min_voltage) / (max_voltage - min_voltage) * 200
         return min(200, percent)
 

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -186,7 +186,7 @@ class BasicCluster(CustomCluster, Basic):
     @staticmethod
     def _calculate_remaining_battery_percentage(voltage):
         """Calculate percentage."""
-        
+
         # Min/Max values from https://github.com/louisZL/lumi-gateway-local-api
         min_voltage = 2800
         max_voltage = 3300

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -186,7 +186,6 @@ class BasicCluster(CustomCluster, Basic):
     @staticmethod
     def _calculate_remaining_battery_percentage(voltage):
         """Calculate percentage."""
-
         # Min/Max values from https://github.com/louisZL/lumi-gateway-local-api
         min_voltage = 2800
         max_voltage = 3300


### PR DESCRIPTION
According to https://github.com/louisZL/lumi-gateway-local-api/blob/master/motion.md, which seems to be the closest to official documentation, the max battery voltage is 3300, and 2800 means low battery.