### PR TITLE
Fix Centralite/Lightify button/switch battery level (#176)

### DIFF
--- a/zhaquirks/centralite/__init__.py
+++ b/zhaquirks/centralite/__init__.py
@@ -15,23 +15,20 @@ class PowerConfigurationCluster(CustomCluster, PowerConfiguration):
     cluster_id = PowerConfiguration.cluster_id
     BATTERY_VOLTAGE_ATTR = 0x0020
     BATTERY_PERCENTAGE_REMAINING = 0x0021
-    MIN_VOLTS = 15
-    MAX_VOLTS = 28
+    MIN_VOLTS = 21
+    MAX_VOLTS = 31
     VOLTS_TO_PERCENT = {
-        28: 100,
-        27: 100,
-        26: 100,
-        25: 90,
-        24: 90,
-        23: 70,
-        22: 70,
-        21: 50,
-        20: 50,
-        19: 30,
-        18: 30,
-        17: 15,
-        16: 1,
-        15: 0,
+        31: 100,
+        30: 90,
+        29: 80,
+        28: 70,
+        27: 60,
+        26: 50,
+        25: 40,
+        24: 30,
+        23: 20,
+        22: 10,
+        21: 0,
     }
 
     def _update_attribute(self, attrid, value):


### PR DESCRIPTION
See #176 for history and where the number used come from.

This updates the battery percentages in the UI for me locally if I use the ZHA configuration UI to get the `battery_voltage` from the individual device.  So far at least other devices haven't shown the update, I'm not sure how ZHA refreshes such information from individual devices normally.