### PR TITLE
xiaomi: send event when "model" attribute is reported

### DIFF
--- a/script/check_format
+++ b/script/check_format
@@ -6,5 +6,4 @@ cd "$(dirname "$0")/.."
 black \
   --check \
   --fast \
-  --quiet \
   zhaquirks tests script *.py

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -117,9 +117,9 @@ class BasicCluster(CustomCluster, Basic):
         else:
             super()._update_attribute(attrid, value)
             if attrid == 0x0005:
-                """0x0005 = model attribute.
-                Xiaomi sensors send the model attribute when their reset button is
-                pressed quickly."""
+                # 0x0005 = model attribute.
+                # Xiaomi sensors send the model attribute when their reset button is
+                # pressed quickly."""
                 self.listener_event(
                     ZHA_SEND_EVENT,
                     self,

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -16,13 +16,18 @@ import zigpy.zcl.foundation as foundation
 
 from .. import Bus, LocalDataCluster
 from ..const import (
+    ATTRIBUTE_ID,
+    ATTRIBUTE_NAME,
     CLUSTER_COMMAND,
+    COMMAND_ATTRIBUTE_UPDATED,
     COMMAND_TRIPLE,
     MOTION_EVENT,
     OFF,
     ON,
+    VALUE,
+    UNKNOWN,
     ZHA_SEND_EVENT,
-    ZONE_STATE,
+    ZONE_STATE
 )
 
 BATTERY_LEVEL = "battery_level"
@@ -111,6 +116,20 @@ class BasicCluster(CustomCluster, Basic):
             attributes = self._parse_mija_attributes(value)
         else:
             super()._update_attribute(attrid, value)
+            if attrid == 0x0005:
+                """0x0005 = model attribute.
+                Xiaomi sensors send the model attribute when their reset button is
+                pressed quickly."""
+                self.listener_event(
+                    ZHA_SEND_EVENT,
+                    self,
+                    COMMAND_ATTRIBUTE_UPDATED,
+                    {
+                        ATTRIBUTE_ID: attrid,
+                        ATTRIBUTE_NAME: self.attributes.get(attrid, [UNKNOWN])[0],
+                        VALUE: value,
+                    },
+                )
             return
 
         _LOGGER.debug(

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -27,7 +27,7 @@ from ..const import (
     VALUE,
     UNKNOWN,
     ZHA_SEND_EVENT,
-    ZONE_STATE
+    ZONE_STATE,
 )
 
 BATTERY_LEVEL = "battery_level"


### PR DESCRIPTION
Some devices, like xiaomi sensors, send the model attribute when their reset button is pressed quickly.
Having this report propagated to HA as an event allows having a sound or light blink when a sensor
button is pressed, which is useful to make sure the sensor is working. This behavior is similar to the
one provided by the Xiaomi Hub (that talks).