### PR TITLE
xiaomi: handle temp sensor reports on Basic cluster

### DIFF
--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -346,6 +346,7 @@ class TemperatureMeasurementCluster(CustomCluster, TemperatureMeasurement):
             super()._update_attribute(attrid, value)
 
     def temperature_reported(self, value):
+        """Temperature reported."""
         self._update_attribute(self.ATTR_ID, value)
 
 
@@ -366,12 +367,12 @@ class RelativeHumidityCluster(CustomCluster, RelativeHumidity):
             super()._update_attribute(attrid, value)
 
     def humidity_reported(self, value):
+        """Humidity reported."""
         self._update_attribute(self.ATTR_ID, value)
 
 
 class PressureMeasurementCluster(CustomCluster, PressureMeasurement):
-    """Pressure cluster to receive reports that are sent to the basic
-     cluster."""
+    """Pressure cluster to receive reports that are sent to the basic cluster."""
 
     cluster_id = PressureMeasurement.cluster_id
     ATTR_ID = 0
@@ -382,4 +383,5 @@ class PressureMeasurementCluster(CustomCluster, PressureMeasurement):
         self.endpoint.device.pressure_bus.add_listener(self)
 
     def pressure_reported(self, value):
+        """Pressure reported."""
         self._update_attribute(self.ATTR_ID, value)

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -153,18 +153,15 @@ class BasicCluster(CustomCluster, Basic):
             )
         if TEMPERATURE_MEASUREMENT in attributes:
             self.endpoint.device.temperature_bus.listener_event(
-                TEMPERATURE_REPORTED,
-                attributes[TEMPERATURE_MEASUREMENT]
+                TEMPERATURE_REPORTED, attributes[TEMPERATURE_MEASUREMENT]
             )
         if HUMIDITY_MEASUREMENT in attributes:
             self.endpoint.device.humidity_bus.listener_event(
-                HUMIDITY_REPORTED,
-                attributes[HUMIDITY_MEASUREMENT]
+                HUMIDITY_REPORTED, attributes[HUMIDITY_MEASUREMENT]
             )
         if PRESSURE_MEASUREMENT in attributes:
             self.endpoint.device.pressure_bus.listener_event(
-                PRESSURE_REPORTED,
-                attributes[PRESSURE_MEASUREMENT]
+                PRESSURE_REPORTED, attributes[PRESSURE_MEASUREMENT]
             )
 
     def _parse_aqara_attributes(self, value):
@@ -179,19 +176,21 @@ class BasicCluster(CustomCluster, Basic):
             10: PATH,
         }
 
-        if (
-            MODEL in self._attr_cache
-            and self._attr_cache[MODEL] in ["lumi.sensor_ht", "lumi.sens",
-                                            "lumi.weather"]
-        ):
+        if MODEL in self._attr_cache and self._attr_cache[MODEL] in [
+            "lumi.sensor_ht",
+            "lumi.sens",
+            "lumi.weather",
+        ]:
             # Temperature sensors send temperature/humidity/pressure updates trough this
             # cluster instead of the respective clusters
-            attribute_names.update({
-                100: TEMPERATURE_MEASUREMENT,
-                101: HUMIDITY_MEASUREMENT,
-                102: PRESSURE_MEASUREMENT,
-            })
-        
+            attribute_names.update(
+                {
+                    100: TEMPERATURE_MEASUREMENT,
+                    101: HUMIDITY_MEASUREMENT,
+                    102: PRESSURE_MEASUREMENT,
+                }
+            )
+
         result = {}
         while value:
             skey = int(value[0])
@@ -334,18 +333,18 @@ class TemperatureMeasurementCluster(CustomCluster, TemperatureMeasurement):
 
     cluster_id = TemperatureMeasurement.cluster_id
     ATTR_ID = 0
-    
+
     def __init__(self, *args, **kwargs):
         """Init."""
         super().__init__(*args, **kwargs)
         self.endpoint.device.temperature_bus.add_listener(self)
-    
+
     def _update_attribute(self, attrid, value):
         # drop values above and below documented range for this sensor
         # value is in centi degrees
         if attrid == self.ATTR_ID and (-2000 <= value <= 6000):
             super()._update_attribute(attrid, value)
-            
+
     def temperature_reported(self, value):
         self._update_attribute(self.ATTR_ID, value)
 
@@ -355,12 +354,12 @@ class RelativeHumidityCluster(CustomCluster, RelativeHumidity):
 
     cluster_id = RelativeHumidity.cluster_id
     ATTR_ID = 0
-    
+
     def __init__(self, *args, **kwargs):
         """Init."""
         super().__init__(*args, **kwargs)
         self.endpoint.device.humidity_bus.add_listener(self)
-    
+
     def _update_attribute(self, attrid, value):
         # drop values above and below documented range for this sensor
         if attrid == self.ATTR_ID and (0 <= value <= 9999):
@@ -376,7 +375,7 @@ class PressureMeasurementCluster(CustomCluster, PressureMeasurement):
 
     cluster_id = PressureMeasurement.cluster_id
     ATTR_ID = 0
-    
+
     def __init__(self, *args, **kwargs):
         """Init."""
         super().__init__(*args, **kwargs)

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -161,7 +161,7 @@ class BasicCluster(CustomCluster, Basic):
             )
         if PRESSURE_MEASUREMENT in attributes:
             self.endpoint.device.pressure_bus.listener_event(
-                PRESSURE_REPORTED, attributes[PRESSURE_MEASUREMENT]
+                PRESSURE_REPORTED, attributes[PRESSURE_MEASUREMENT] / 100
             )
 
     def _parse_aqara_attributes(self, value):

--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -8,6 +8,7 @@ from zigpy.quirks import CustomCluster, CustomDevice
 from zigpy.zcl.clusters.general import Basic, PowerConfiguration
 from zigpy.zcl.clusters.measurement import (
     OccupancySensing,
+    PressureMeasurement,
     RelativeHumidity,
     TemperatureMeasurement,
 )
@@ -35,13 +36,19 @@ BATTERY_PERCENTAGE_REMAINING = 0x0021
 BATTERY_REPORTED = "battery_reported"
 BATTERY_SIZE = "battery_size"
 BATTERY_VOLTAGE_MV = "battery_voltage_mV"
+HUMIDITY_MEASUREMENT = "humidity_measurement"
+HUMIDITY_REPORTED = "humidity_reported"
 LUMI = "LUMI"
 MODEL = 5
 MOTION_TYPE = 0x000D
 OCCUPANCY_STATE = 0
 PATH = "path"
+PRESSURE_MEASUREMENT = "pressure_measurement"
+PRESSURE_REPORTED = "pressure_reported"
 STATE = "state"
 TEMPERATURE = "temperature"
+TEMPERATURE_MEASUREMENT = "temperature_measurement"
+TEMPERATURE_REPORTED = "temperature_reported"
 XIAOMI_AQARA_ATTRIBUTE = 0xFF01
 XIAOMI_ATTR_3 = "X-attrib-3"
 XIAOMI_ATTR_4 = "X-attrib-4"
@@ -144,6 +151,21 @@ class BasicCluster(CustomCluster, Basic):
                 attributes[BATTERY_LEVEL],
                 attributes[BATTERY_VOLTAGE_MV],
             )
+        if TEMPERATURE_MEASUREMENT in attributes:
+            self.endpoint.device.temperature_bus.listener_event(
+                TEMPERATURE_REPORTED,
+                attributes[TEMPERATURE_MEASUREMENT]
+            )
+        if HUMIDITY_MEASUREMENT in attributes:
+            self.endpoint.device.humidity_bus.listener_event(
+                HUMIDITY_REPORTED,
+                attributes[HUMIDITY_MEASUREMENT]
+            )
+        if PRESSURE_MEASUREMENT in attributes:
+            self.endpoint.device.pressure_bus.listener_event(
+                PRESSURE_REPORTED,
+                attributes[PRESSURE_MEASUREMENT]
+            )
 
     def _parse_aqara_attributes(self, value):
         """Parse non standard atrributes."""
@@ -156,6 +178,20 @@ class BasicCluster(CustomCluster, Basic):
             6: XIAOMI_ATTR_6,
             10: PATH,
         }
+
+        if (
+            MODEL in self._attr_cache
+            and self._attr_cache[MODEL] in ["lumi.sensor_ht", "lumi.sens",
+                                            "lumi.weather"]
+        ):
+            # Temperature sensors send temperature/humidity/pressure updates trough this
+            # cluster instead of the respective clusters
+            attribute_names.update({
+                100: TEMPERATURE_MEASUREMENT,
+                101: HUMIDITY_MEASUREMENT,
+                102: PRESSURE_MEASUREMENT,
+            })
+        
         result = {}
         while value:
             skey = int(value[0])
@@ -297,21 +333,54 @@ class TemperatureMeasurementCluster(CustomCluster, TemperatureMeasurement):
     """Temperature cluster that filters out invalid temperature readings."""
 
     cluster_id = TemperatureMeasurement.cluster_id
-
+    ATTR_ID = 0
+    
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self.endpoint.device.temperature_bus.add_listener(self)
+    
     def _update_attribute(self, attrid, value):
         # drop values above and below documented range for this sensor
         # value is in centi degrees
-        if attrid == 0 and (-2000 <= value <= 6000):
+        if attrid == self.ATTR_ID and (-2000 <= value <= 6000):
             super()._update_attribute(attrid, value)
+            
+    def temperature_reported(self, value):
+        self._update_attribute(self.ATTR_ID, value)
 
 
 class RelativeHumidityCluster(CustomCluster, RelativeHumidity):
     """Humidity cluster that filters out invalid humidity readings."""
 
     cluster_id = RelativeHumidity.cluster_id
-
+    ATTR_ID = 0
+    
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self.endpoint.device.humidity_bus.add_listener(self)
+    
     def _update_attribute(self, attrid, value):
         # drop values above and below documented range for this sensor
-        # value is in centi degrees
-        if attrid == 0 and (0 <= value <= 9999):
+        if attrid == self.ATTR_ID and (0 <= value <= 9999):
             super()._update_attribute(attrid, value)
+
+    def humidity_reported(self, value):
+        self._update_attribute(self.ATTR_ID, value)
+
+
+class PressureMeasurementCluster(CustomCluster, PressureMeasurement):
+    """Pressure cluster to receive reports that are sent to the basic
+     cluster."""
+
+    cluster_id = PressureMeasurement.cluster_id
+    ATTR_ID = 0
+    
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self.endpoint.device.pressure_bus.add_listener(self)
+
+    def pressure_reported(self, value):
+        self._update_attribute(self.ATTR_ID, value)

--- a/zhaquirks/xiaomi/aqara/weather.py
+++ b/zhaquirks/xiaomi/aqara/weather.py
@@ -11,10 +11,12 @@ from .. import (
     LUMI,
     BasicCluster,
     PowerConfigurationCluster,
+    PressureMeasurementCluster,
     RelativeHumidityCluster,
     TemperatureMeasurementCluster,
     XiaomiCustomDevice,
 )
+from ... import Bus
 from ...const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -36,6 +38,13 @@ if AqaraTemperatureHumiditySensor in quirks._DEVICE_REGISTRY:
 
 class Weather(XiaomiCustomDevice):
     """Xiaomi weather sensor device."""
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        self.temperature_bus = Bus()
+        self.humidity_bus = Bus()
+        self.pressure_bus = Bus()
+        super().__init__(*args, **kwargs)
 
     signature = {
         #  <SimpleDescriptor endpoint=1 profile=260 device_type=24321
@@ -72,7 +81,7 @@ class Weather(XiaomiCustomDevice):
                     PowerConfigurationCluster,
                     Identify.cluster_id,
                     TemperatureMeasurementCluster,
-                    PressureMeasurement.cluster_id,
+                    PressureMeasurementCluster,
                     RelativeHumidityCluster,
                     XIAOMI_CLUSTER_ID,
                 ],

--- a/zhaquirks/xiaomi/mija/sensor_ht.py
+++ b/zhaquirks/xiaomi/mija/sensor_ht.py
@@ -21,6 +21,7 @@ from .. import (
     TemperatureMeasurementCluster,
     XiaomiCustomDevice,
 )
+from ... import Bus
 from ...const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -44,6 +45,12 @@ if TemperatureHumiditySensor in quirks._DEVICE_REGISTRY:
 
 class Weather(XiaomiCustomDevice):
     """Xiaomi mija weather sensor device."""
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        self.temperature_bus = Bus()
+        self.humidity_bus = Bus()
+        super().__init__(*args, **kwargs)
 
     signature = {
         #  <SimpleDescriptor endpoint=1 profile=260 device_type=24321


### PR DESCRIPTION
Xiaomi Temperature sensors report frequent updates on the basic cluster. This redirects those updates to the correct clusters.
See https://github.com/Koenkk/zigbee2mqtt/issues/327 for more info.