### PR TITLE
Update to xbee quirks to account for changes in zigpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import find_packages, setup
 
-VERSION = "0.0.28"
+VERSION = "0.0.29"
 
 
 def readme():

--- a/zhaquirks/xbee/xbee3_io.py
+++ b/zhaquirks/xbee/xbee3_io.py
@@ -169,7 +169,7 @@ class XBee3Sensor(CustomDevice):
 
         cluster_id = XBEE_IO_CLUSTER
 
-        def handle_cluster_general_request(self, tsn, command_id, args):
+        def handle_cluster_request(self, tsn, command_id, args):
             """Handle the cluster general request.
 
             Update the digital pin states
@@ -189,7 +189,7 @@ class XBee3Sensor(CustomDevice):
                             ON_OFF_CMD, values["digital_samples"][pin]
                         )
             else:
-                super().handle_cluster_general_request(tsn, command_id, args)
+                super().handle_cluster_request(tsn, command_id, args)
 
         def deserialize(self, data):
             """Deserialize."""
@@ -217,9 +217,11 @@ class XBee3Sensor(CustomDevice):
                         is_reply = commands[new_command_id][2]
                     except KeyError:
                         self.warn("Unknown cluster-specific command %s", hdr.command_id)
-                        return hdr.tsn, hdr.command_id + 256, hdr.is_reply, data
+                        hdr.command_id += 256
+                        return hdr, data
                     value, data = t.deserialize(data, schema)
-                    return hdr.tsn, new_command_id, hdr.is_reply, value
+                    hdr.command_id = ON_OFF_CMD
+                    return hdr, value
                 # Bad hack to differentiate foundation vs cluster
                 hdr.command_id = hdr.command_id + 256
             else:
@@ -229,12 +231,12 @@ class XBee3Sensor(CustomDevice):
                     is_reply = foundation.COMMANDS[hdr.command_id][1]
                 except KeyError:
                     self.warn("Unknown foundation command %s", hdr.command_id)
-                    return hdr.tsn, hdr.command_id, hdr.is_reply, data
+                    return hdr, data
 
             value, data = t.deserialize(data, schema)
             if data != b"":
                 _LOGGER.warning("Data remains after deserializing ZCL frame")
-            return hdr.tsn, hdr.command_id, is_reply, value
+            return hdr, value
 
         attributes = {0x0055: ("present_value", t.Bool)}
         client_commands = {0x0000: ("io_sample", (IOSample,), False)}


### PR DESCRIPTION
Changes in zigpy caused these quirks to no longer report status changes of DIO pins and resulted in the following error.

```ValueError: too many values to unpack (expected 2)```

This corrects the return of the deserialize functions and renames the handle_cluster_general_request to handle_cluster_request.

Tested the reading and writing pin states, did not test the additional serial/event functionality.