### PR TITLE
[WIP] Revert centralite battery map, add new 3.1v map

### DIFF
--- a/zhaquirks/centralite/3130.py
+++ b/zhaquirks/centralite/3130.py
@@ -11,7 +11,7 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 
-from zhaquirks.centralite import CENTRALITE, PowerConfigurationCluster
+from zhaquirks.centralite import CENTRALITE, PowerConfigurationCluster31
 from zhaquirks.const import (
     COMMAND,
     COMMAND_MOVE,
@@ -50,7 +50,7 @@ class CentraLite3130(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
+                    PowerConfigurationCluster31.cluster_id,
                     Identify.cluster_id,
                     PollControl.cluster_id,
                     TemperatureMeasurement.cluster_id,
@@ -70,7 +70,7 @@ class CentraLite3130(CustomDevice):
             1: {
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfigurationCluster,
+                    PowerConfigurationCluster31,
                     Identify.cluster_id,
                     PollControl.cluster_id,
                     DIAGNOSTICS_CLUSTER_ID,

--- a/zhaquirks/centralite/3460L.py
+++ b/zhaquirks/centralite/3460L.py
@@ -12,7 +12,7 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.measurement import TemperatureMeasurement
 
-from zhaquirks.centralite import CENTRALITE, PowerConfigurationCluster
+from zhaquirks.centralite import CENTRALITE, PowerConfigurationCluster31
 from zhaquirks.const import (
     DEVICE_TYPE,
     ENDPOINTS,
@@ -40,7 +40,7 @@ class CentraLite3460L(CustomDevice):
                 DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfigurationCluster.cluster_id,
+                    PowerConfigurationCluster31.cluster_id,
                     Identify.cluster_id,
                     OnOffConfiguration.cluster_id,
                     PollControl.cluster_id,
@@ -61,7 +61,7 @@ class CentraLite3460L(CustomDevice):
             1: {
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
-                    PowerConfigurationCluster,
+                    PowerConfigurationCluster31,
                     Identify.cluster_id,
                     OnOffConfiguration.cluster_id,
                     PollControl.cluster_id,

--- a/zhaquirks/centralite/__init__.py
+++ b/zhaquirks/centralite/__init__.py
@@ -10,7 +10,53 @@ CENTRALITE = "CentraLite"
 
 
 class PowerConfigurationCluster(CustomCluster, PowerConfiguration):
-    """Centralite power configuration cluster."""
+    """Centralite 2.8-1.5V power configuration cluster."""
+
+    cluster_id = PowerConfiguration.cluster_id
+    BATTERY_VOLTAGE_ATTR = 0x0020
+    BATTERY_PERCENTAGE_REMAINING = 0x0021
+    MIN_VOLTS = 15
+    MAX_VOLTS = 28
+    VOLTS_TO_PERCENT = {
+        28: 100,
+        27: 100,
+        26: 100,
+        25: 90,
+        24: 90,
+        23: 70,
+        22: 70,
+        21: 50,
+        20: 50,
+        19: 30,
+        18: 30,
+        17: 15,
+        16: 1,
+        15: 0,
+    }
+
+    def _update_attribute(self, attrid, value):
+        super()._update_attribute(attrid, value)
+        if attrid == self.BATTERY_VOLTAGE_ATTR:
+            super()._update_attribute(
+                self.BATTERY_PERCENTAGE_REMAINING,
+                self._calculate_battery_percentage(value),
+            )
+
+    def _calculate_battery_percentage(self, raw_value):
+        volts = raw_value
+        if raw_value < self.MIN_VOLTS:
+            volts = self.MIN_VOLTS
+        elif raw_value > self.MAX_VOLTS:
+            volts = self.MAX_VOLTS
+
+        percent = self.VOLTS_TO_PERCENT.get(volts, -1)
+        if percent != -1:
+            percent = percent * 2
+        return percent
+
+
+class PowerConfigurationCluster31(CustomCluster, PowerConfiguration):
+    """Centralite 3.1-2.1V power configuration cluster."""
 
     cluster_id = PowerConfiguration.cluster_id
     BATTERY_VOLTAGE_ATTR = 0x0020


### PR DESCRIPTION
To open discussion...

Reverts centralite battery map to last know working map. Uses [2.8-1.5v battery logic](https://github.com/SmartThingsCommunity/SmartThingsPublic/blob/master/devicetypes/smartthings/smartsense-multi-sensor.src/smartsense-multi-sensor.groovy#L294-L297) for centralite/smartthings.

Incorporates logic from: [Smartthings Zigbee Button](https://github.com/SmartThingsCommunity/SmartThingsPublic/blob/2ec2ca46f05e82a190d44890b9f7fe72dc4c3e85/devicetypes/smartthings/zigbee-button.src/zigbee-button.groovy) for #176.

Reverts: 6cba0ff
Fixes: #199 
Potential fix: #176 