### PR TITLE
Changed the way the args were being parsed to prevent duplicate trigg…

### DIFF
--- a/zhaquirks/ikea/fivebtnremote.py
+++ b/zhaquirks/ikea/fivebtnremote.py
@@ -56,8 +56,8 @@ class ScenesCluster(EventableCluster, Scenes):
         super().__init__(*args, **kwargs)
         self.server_commands.update(
             {
-                0x0007: ("press", (t.int8s, t.int8s, t.int8s, t.int8s), False),
-                0x0008: ("hold", (t.int8s, t.int8s, t.int8s), False),
+                0x0007: ("press", (t.int16s, t.int8s, t.int8s), False),
+                0x0008: ("hold", (t.int16s, t.int8s), False),
                 0x0009: ("release", (t.int16s,), False),
             }
         )
@@ -163,24 +163,24 @@ class IkeaTradfriRemote(CustomDevice):
             COMMAND: COMMAND_PRESS,
             CLUSTER_ID: 5,
             ENDPOINT_ID: 1,
-            ARGS: [1, 1, 13, 0],
+            ARGS: [257, 13, 0],
         },
         (LONG_PRESS, LEFT): {
             COMMAND: COMMAND_HOLD,
             CLUSTER_ID: 5,
             ENDPOINT_ID: 1,
-            ARGS: [1, 13, 0],
+            ARGS: [3329, 0],
         },
         (SHORT_PRESS, RIGHT): {
             COMMAND: COMMAND_PRESS,
             CLUSTER_ID: 5,
             ENDPOINT_ID: 1,
-            ARGS: [0, 1, 13, 0],
+            ARGS: [256, 13, 0],
         },
         (LONG_PRESS, RIGHT): {
             COMMAND: COMMAND_HOLD,
             CLUSTER_ID: 5,
             ENDPOINT_ID: 1,
-            ARGS: [0, 13, 0],
+            ARGS: [3328, 0],
         },
     }


### PR DESCRIPTION
Changed the way the args were being parsed to prevent duplicate triggers.

Due to the way that the args are matched in HA, the current
implementation meant that the left and right button were each firing
triggers for both themself, and the other. So left would fire
automations triggered on left and right, and vice versa.

I've changed the "press" and "hold" command parsing to start with a
16 bit int, the same as release, this prevents the zeros being
generated for both, which was spooking the way that HA matches these.