### PR TITLE
Xbee analog input

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ If you are looking to make your first code contribution to this project then we 
 
 - Some functionality requires a coordinator device to be XBee as well
 - GPIO pins are exposed to Home Assistant as switches
+- Analog inputs are exposed as sensors
 - Outgoing UART data can be sent with `zha.issue_zigbee_cluster_command` service
 - Incoming UART data will generate `zha_event` event.
 

--- a/zhaquirks/xbee/xbee3_io.py
+++ b/zhaquirks/xbee/xbee3_io.py
@@ -1,8 +1,10 @@
 """Class to control Xbee3 device."""
 
 from zigpy.profiles import zha
-from ..const import DEVICE_TYPE, ENDPOINTS, INPUT_CLUSTERS, OUTPUT_CLUSTERS, PROFILE_ID
+from zigpy.zcl.clusters.general import AnalogInput
+
 from . import XBEE_PROFILE_ID, XBeeCommon, XBeeOnOff
+from ..const import DEVICE_TYPE, ENDPOINTS, INPUT_CLUSTERS, OUTPUT_CLUSTERS, PROFILE_ID
 
 
 class XBee3Sensor(XBeeCommon):
@@ -17,7 +19,7 @@ class XBee3Sensor(XBeeCommon):
                     "model": "AD0/DIO0/Commissioning",
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
-                    INPUT_CLUSTERS: [XBeeOnOff],
+                    INPUT_CLUSTERS: [XBeeOnOff, AnalogInput],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xD1: {
@@ -25,7 +27,7 @@ class XBee3Sensor(XBeeCommon):
                     "model": "AD1/DIO1/SPI_nATTN",
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
-                    INPUT_CLUSTERS: [XBeeOnOff],
+                    INPUT_CLUSTERS: [XBeeOnOff, AnalogInput],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xD2: {
@@ -33,7 +35,7 @@ class XBee3Sensor(XBeeCommon):
                     "model": "AD2/DIO2/SPI_CLK",
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
-                    INPUT_CLUSTERS: [XBeeOnOff],
+                    INPUT_CLUSTERS: [XBeeOnOff, AnalogInput],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xD3: {
@@ -41,7 +43,7 @@ class XBee3Sensor(XBeeCommon):
                     "model": "AD3/DIO3",
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
-                    INPUT_CLUSTERS: [XBeeOnOff],
+                    INPUT_CLUSTERS: [XBeeOnOff, AnalogInput],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xD4: {
@@ -58,6 +60,14 @@ class XBee3Sensor(XBeeCommon):
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff],
+                    OUTPUT_CLUSTERS: [],
+                },
+                0xD7: {
+                    "manufacturer": "XBEE",
+                    "model": "SupplyVoltage",
+                    DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
+                    PROFILE_ID: XBEE_PROFILE_ID,
+                    INPUT_CLUSTERS: [AnalogInput],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xD8: {

--- a/zhaquirks/xbee/xbee_io.py
+++ b/zhaquirks/xbee/xbee_io.py
@@ -1,8 +1,10 @@
 """Class to control Xbee device."""
 
 from zigpy.profiles import zha
-from ..const import DEVICE_TYPE, ENDPOINTS, INPUT_CLUSTERS, OUTPUT_CLUSTERS, PROFILE_ID
+from zigpy.zcl.clusters.general import AnalogInput
+
 from . import XBEE_PROFILE_ID, XBeeCommon, XBeeOnOff
+from ..const import DEVICE_TYPE, ENDPOINTS, INPUT_CLUSTERS, OUTPUT_CLUSTERS, PROFILE_ID
 
 
 class XBeeSensor(XBeeCommon):
@@ -17,7 +19,7 @@ class XBeeSensor(XBeeCommon):
                     "model": "AD0/DIO0/Commissioning",
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
-                    INPUT_CLUSTERS: [XBeeOnOff],
+                    INPUT_CLUSTERS: [XBeeOnOff, AnalogInput],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xD1: {
@@ -25,7 +27,7 @@ class XBeeSensor(XBeeCommon):
                     "model": "AD1/DIO1/SPI_nATTN",
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
-                    INPUT_CLUSTERS: [XBeeOnOff],
+                    INPUT_CLUSTERS: [XBeeOnOff, AnalogInput],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xD2: {
@@ -33,7 +35,7 @@ class XBeeSensor(XBeeCommon):
                     "model": "AD2/DIO2/SPI_CLK",
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
-                    INPUT_CLUSTERS: [XBeeOnOff],
+                    INPUT_CLUSTERS: [XBeeOnOff, AnalogInput],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xD3: {
@@ -41,7 +43,7 @@ class XBeeSensor(XBeeCommon):
                     "model": "AD3/DIO3",
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
-                    INPUT_CLUSTERS: [XBeeOnOff],
+                    INPUT_CLUSTERS: [XBeeOnOff, AnalogInput],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xD4: {
@@ -58,6 +60,14 @@ class XBeeSensor(XBeeCommon):
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
                     INPUT_CLUSTERS: [XBeeOnOff],
+                    OUTPUT_CLUSTERS: [],
+                },
+                0xD7: {
+                    "manufacturer": "XBEE",
+                    "model": "SupplyVoltage",
+                    DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
+                    PROFILE_ID: XBEE_PROFILE_ID,
+                    INPUT_CLUSTERS: [AnalogInput],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xDA: {


### PR DESCRIPTION
Expose analog inputs to HA.
The sensors show voltage in percent relative to the analog reference voltage. 0 is 0V and 100 is the analog reference voltage or above.
The analog reference voltage is 1.2V for XBee and selectable between 1.25V, 2.5V and VDD with AV command for XBee3.
The supply voltage is measured in V if enabled with V+ command.