### PR TITLE
Fix LocalDataCluster

### DIFF
--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -43,7 +43,7 @@ class LocalDataCluster(CustomCluster):
         ]
         for record in records:
             record.value.value = self._attr_cache.get(record.attrid)
-            if record.value.value:
+            if record.value.value is not None:
                 record.status = foundation.Status.SUCCESS
         return [records]
 

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -4,7 +4,6 @@ import importlib
 import pkgutil
 
 from zigpy.quirks import CustomCluster
-import zigpy.types as types
 from zigpy.util import ListenableMixin
 from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import PowerConfiguration

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -6,6 +6,7 @@ import pkgutil
 from zigpy.quirks import CustomCluster
 import zigpy.types as types
 from zigpy.util import ListenableMixin
+from zigpy.zcl import foundation
 from zigpy.zcl.clusters.general import PowerConfiguration
 from zigpy.zdo import types as zdotypes
 
@@ -35,9 +36,17 @@ class LocalDataCluster(CustomCluster):
 
     async def read_attributes_raw(self, attributes, manufacturer=None):
         """Prevent remote reads."""
-        attributes = [types.uint16_t(a) for a in attributes]
-        values = [self._attr_cache.get(attr) for attr in attributes]
-        return values
+        records = [
+            foundation.ReadAttributeRecord(
+                attr, foundation.Status.UNSUPPORTED_ATTRIBUTE, foundation.TypeValue()
+            )
+            for attr in attributes
+        ]
+        for record in records:
+            record.value.value = self._attr_cache.get(record.attrid)
+            if record.value.value:
+                record.status = foundation.Status.SUCCESS
+        return [records]
 
 
 class EventableCluster(CustomCluster):


### PR DESCRIPTION
Fixed attribute read for LocalDataCluster. 
The zigpy.zcl.Cluster.read_attributes() function seems to require a more complex data structure in the response than just an array of values.