### PR TITLE
LocalDataCluster: prevent remote attribute writes

### DIFF
--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -49,7 +49,6 @@ class LocalDataCluster(CustomCluster):
 
     async def write_attributes(self, attributes, manufacturer=None):
         """Prevent remote writes."""
-        args = []
         for attrid, value in attributes.items():
             if isinstance(attrid, str):
                 attrid = self._attridx[attrid]

--- a/zhaquirks/__init__.py
+++ b/zhaquirks/__init__.py
@@ -45,7 +45,19 @@ class LocalDataCluster(CustomCluster):
             record.value.value = self._attr_cache.get(record.attrid)
             if record.value.value is not None:
                 record.status = foundation.Status.SUCCESS
-        return [records]
+        return (records,)
+
+    async def write_attributes(self, attributes, manufacturer=None):
+        """Prevent remote writes."""
+        args = []
+        for attrid, value in attributes.items():
+            if isinstance(attrid, str):
+                attrid = self._attridx[attrid]
+            if attrid not in self.attributes:
+                self.error("%d is not a valid attribute id", attrid)
+                continue
+            self._update_attribute(attrid, value)
+        return (foundation.Status.SUCCESS,)
 
 
 class EventableCluster(CustomCluster):


### PR DESCRIPTION
If I understand the idea of the LocalDataCluster, we should as well prevent remote attribute writes