### PR TITLE
XBee PWM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ If you are looking to make your first code contribution to this project then we 
 - Some functionality requires a coordinator device to be XBee as well
 - GPIO pins are exposed to Home Assistant as switches
 - Analog inputs are exposed as sensors
+- PWM output on XBee3 can be controlled by writing 0x0055 (present_value) cluster attribute with `zha.set_zigbee_cluster_attribute` service
 - Outgoing UART data can be sent with `zha.issue_zigbee_cluster_command` service
 - Incoming UART data will generate `zha_event` event.
 

--- a/zhaquirks/xbee/xbee3_io.py
+++ b/zhaquirks/xbee/xbee3_io.py
@@ -3,7 +3,7 @@
 from zigpy.profiles import zha
 from zigpy.zcl.clusters.general import AnalogInput
 
-from . import XBEE_PROFILE_ID, XBeeCommon, XBeeOnOff
+from . import XBEE_PROFILE_ID, XBeeCommon, XBeeOnOff, XBeePWM
 from ..const import DEVICE_TYPE, ENDPOINTS, INPUT_CLUSTERS, OUTPUT_CLUSTERS, PROFILE_ID
 
 
@@ -91,7 +91,7 @@ class XBee3Sensor(XBeeCommon):
                     "model": "DIO10/PWM0",
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
-                    INPUT_CLUSTERS: [XBeeOnOff],
+                    INPUT_CLUSTERS: [XBeeOnOff, XBeePWM],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xDB: {
@@ -99,7 +99,7 @@ class XBee3Sensor(XBeeCommon):
                     "model": "DIO11/PWM1",
                     DEVICE_TYPE: zha.DeviceType.LEVEL_CONTROL_SWITCH,
                     PROFILE_ID: XBEE_PROFILE_ID,
-                    INPUT_CLUSTERS: [XBeeOnOff],
+                    INPUT_CLUSTERS: [XBeeOnOff, XBeePWM],
                     OUTPUT_CLUSTERS: [],
                 },
                 0xDC: {


### PR DESCRIPTION
PWM output support for XBee3 by adding of an AnalogOutput cluster.

Important points:
- Requires zigpy-xbee>=0.8.0 to work
- HA support for AnalogOutput clusters is not ready yet, but one can still use the functionality of this PR with `zha.set_zigbee_cluster_attribute` service for `present_value` attribute. And here is a proof-of-concept code for the full HA support: home-assistant/home-assistant#30211