### PR TITLE
Add quirk for Sinope TH1400ZB themrostat.

### DIFF
--- a/zhaquirks/sinope/thermostat.py
+++ b/zhaquirks/sinope/thermostat.py
@@ -5,6 +5,7 @@ manufacturer specific cluster implements attributes to control displaying
 of outdoor temperature, setting occupancy on/off and setting device time.
 """
 
+import zigpy.profiles.zha as zha_p
 from zigpy.quirks import CustomCluster, CustomDevice
 import zigpy.types as t
 from zigpy.zcl.clusters.general import (
@@ -32,35 +33,29 @@ from ..const import (
 SINOPE_MANUFACTURER_CLUSTER_ID = 0xFF01
 
 
+class SinopeTechnologiesManufacturerCluster(CustomCluster):
+    """SinopeTechnologiesManufacturerCluster manufacturer cluster."""
+
+    cluster_id = SINOPE_MANUFACTURER_CLUSTER_ID
+    name = "Sinopé Technologies Manufacturer specific"
+    ep_attribute = "sinope_manufacturer_specific"
+    attributes = {
+        0x0010: ("outdoor_temp", t.int16s),
+        0x0020: ("secs_since_2k", t.uint32_t),
+    }
+    client_commands = {}
+    server_commands = {}
+
+
+class SinopeTechnologiesThermostatCluster(CustomCluster, Thermostat):
+    """SinopeTechnologiesThermostatCluster custom cluster."""
+
+    attributes = Thermostat.attributes.copy()
+    attributes[0x0400] = ("set_occupancy", t.enum8)
+
+
 class SinopeTechnologiesThermostat(CustomDevice):
     """SinopeTechnologiesThermostat custom device."""
-
-    class SinopeTechnologiesManufacturerCluster(CustomCluster):
-        """SinopeTechnologiesManufacturerCluster manufacturer cluster."""
-
-        cluster_id = SINOPE_MANUFACTURER_CLUSTER_ID
-        name = "Sinopé Technologies Manufacturer specific"
-        ep_attribute = "sinope_manufacturer_specific"
-        attributes = {
-            0x0010: ("outdoor_temp", t.int16s),
-            0x0020: ("secs_since_2k", t.uint32_t),
-        }
-        client_commands = {}
-        server_commands = {}
-
-        def __init__(self, *args, **kwargs):
-            """Init method."""
-            super().__init__(*args, **kwargs)
-            self._attridx = {
-                attrname: attrid
-                for attrid, (attrname, datatype) in self.attributes.items()
-            }
-
-    class SinopeTechnologiesThermostatCluster(CustomCluster, Thermostat):
-        """SinopeTechnologiesThermostatCluster custom cluster."""
-
-        attributes = Thermostat.attributes.copy()
-        attributes[0x0400] = ("set_occupancy", t.enum8)
 
     signature = {
         # <SimpleDescriptor endpoint=1 profile=260 device_type=769
@@ -69,8 +64,8 @@ class SinopeTechnologiesThermostat(CustomDevice):
         MODELS_INFO: [(SINOPE, "TH1123ZB"), (SINOPE, "TH1124ZB")],
         ENDPOINTS: {
             1: {
-                PROFILE_ID: 0x0104,
-                DEVICE_TYPE: 0x0301,
+                PROFILE_ID: zha_p.PROFILE_ID,
+                DEVICE_TYPE: zha_p.DeviceType.THERMOSTAT,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     Identify.cluster_id,
@@ -89,7 +84,7 @@ class SinopeTechnologiesThermostat(CustomDevice):
             # device_version=0 input_clusters=[1] output_clusters=[]>
             196: {
                 PROFILE_ID: 0xC25D,
-                DEVICE_TYPE: 0x0301,
+                DEVICE_TYPE: zha_p.DeviceType.THERMOSTAT,
                 INPUT_CLUSTERS: [PowerConfiguration.cluster_id],
                 OUTPUT_CLUSTERS: [],
             },
@@ -116,3 +111,4 @@ class SinopeTechnologiesThermostat(CustomDevice):
             196: {INPUT_CLUSTERS: [PowerConfiguration]},
         }
     }
+

--- a/zhaquirks/sinope/thermostat.py
+++ b/zhaquirks/sinope/thermostat.py
@@ -15,10 +15,12 @@ from zigpy.zcl.clusters.general import (
     Ota,
     PowerConfiguration,
     Scenes,
+    Time,
 )
 from zigpy.zcl.clusters.homeautomation import Diagnostic, ElectricalMeasurement
 from zigpy.zcl.clusters.hvac import Thermostat, UserInterface
 from zigpy.zcl.clusters.measurement import TemperatureMeasurement
+from zigpy.zcl.clusters.smartenergy import Metering
 
 from . import SINOPE
 from ..const import (
@@ -112,3 +114,56 @@ class SinopeTechnologiesThermostat(CustomDevice):
         }
     }
 
+
+class SinopeTH1400ZB(SinopeTechnologiesThermostat):
+    """TH1400ZB thermostat."""
+
+    signature = {
+        # <SimpleDescriptor endpoint=1 profile=260 device_type=769 device_version=1
+        # input_clusters=[0, 3, 4, 5, 513, 516, 1026, 1794, 2821, 65281]
+        # output_clusters=[10, 65281, 25]>
+        MODELS_INFO: [(SINOPE, "TH11400ZB")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha_p.PROFILE_ID,
+                DEVICE_TYPE: zha_p.DeviceType.THERMOSTAT,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    Scenes.cluster_id,
+                    Thermostat.cluster_id,
+                    UserInterface.cluster_id,
+                    TemperatureMeasurement.cluster_id,
+                    Metering.cluster_id,
+                    Diagnostic.cluster_id,
+                    SINOPE_MANUFACTURER_CLUSTER_ID,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Time.cluster_id,
+                    Ota.cluster_id,
+                    SINOPE_MANUFACTURER_CLUSTER_ID,
+                ],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                INPUT_CLUSTERS: [
+                    Basic,
+                    Identify,
+                    Groups,
+                    Scenes,
+                    UserInterface,
+                    TemperatureMeasurement,
+                    Metering,
+                    Diagnostic,
+                    SinopeTechnologiesThermostatCluster,
+                    SinopeTechnologiesManufacturerCluster,
+                ],
+                OUTPUT_CLUSTERS: [Time, Ota, SINOPE_MANUFACTURER_CLUSTER_ID],
+            }
+        }
+    }


### PR DESCRIPTION
Add new Sinope thermostat. 
```
Discovering endpoints
Discovered endpoints: [1]
Discovering endpoint information
Discovered endpoint information: <SimpleDescriptor endpoint=1 profile=260 device_type=769 device_version=1 input_clusters=[0, 3, 4, 5, 513, 516, 1026, 1794, 2821, 65281] output_clusters=[10, 65281, 25]>
Manufacturer: Sinope Technologies
Model: TH1400ZB
```

Fixes #185 