### PR TITLE
Add quirk for Trust ZPIR-8000

### DIFF
--- a/zhaquirks/trust/__init__.py
+++ b/zhaquirks/trust/__init__.py
@@ -1,0 +1,33 @@
+"""Trust."""
+import asyncio
+
+from zigpy.quirks import CustomCluster
+from zigpy.zcl.clusters.security import IasZone
+
+from ..const import CLUSTER_COMMAND, OFF, ZONE_STATE
+
+TRUST = "Trust"
+
+
+class MotionCluster(CustomCluster, IasZone):
+    """Motion cluster."""
+
+    cluster_id = IasZone.cluster_id
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self._timer_handle = None
+
+    def handle_cluster_request(self, tsn, command_id, args):
+        """Handle the cluster command."""
+        if command_id == 0:
+            if self._timer_handle:
+                self._timer_handle.cancel()
+            loop = asyncio.get_event_loop()
+            self._timer_handle = loop.call_later(30, self._turn_off)
+
+    def _turn_off(self):
+        self._timer_handle = None
+        self.listener_event(CLUSTER_COMMAND, 999, 0, [0, 0, 0, 0])
+        self._update_attribute(ZONE_STATE, OFF)

--- a/zhaquirks/trust/zpir8000.py
+++ b/zhaquirks/trust/zpir8000.py
@@ -1,0 +1,58 @@
+"""Device handler for Trust ZPIR-8000 sensors."""
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.general import Basic, Identify, PowerConfiguration
+from zigpy.zcl.clusters.security import IasZone
+
+from zhaquirks.const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+from . import MotionCluster
+
+MANUFACTURER_SPECIFIC_CLUSTER_ID = 0xFFFF
+
+
+class ZPIR8000(CustomDevice):
+    """Trust ZPIR-8000."""
+
+    signature = {
+        #  <SimpleDescriptor endpoint=1 profile=260 device_type=1026
+        # device_version=1
+        # input_clusters=[0, 3, 1280, 65535, 1]
+        # output_clusters=[]>
+        MODELS_INFO: [("ADUROLIGHT", "VMS_ADUROLIGHT")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    IasZone.cluster_id,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                    PowerConfiguration.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    MotionCluster,
+                    MANUFACTURER_SPECIFIC_CLUSTER_ID,
+                ]
+            }
+        }
+    }


### PR DESCRIPTION
Trust ZPIR-8000 does not send any commands when no motion is detected for a while. This quirk adds support by setting a 30 seconds timer which clears the state.