### PR TITLE
Add Konke motion sensors

### DIFF
--- a/zhaquirks/ikea/symfonisk.py
+++ b/zhaquirks/ikea/symfonisk.py
@@ -1,0 +1,129 @@
+"""Device handler for IKEA of Sweden TRADFRI SYMFONISK remote control."""
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Groups,
+    Identify,
+    LevelControl,
+    OnOff,
+    Ota,
+    PollControl,
+    PowerConfiguration,
+)
+from zigpy.zcl.clusters.lightlink import LightLink
+
+from . import IKEA
+from .. import DoublingPowerConfigurationCluster
+from ..const import (
+    ARGS,
+    CLUSTER_ID,
+    COMMAND,
+    COMMAND_MOVE,
+    COMMAND_STEP,
+    COMMAND_TOGGLE,
+    DEVICE_TYPE,
+    DOUBLE_PRESS,
+    ENDPOINT_ID,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    LEFT,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+    RIGHT,
+    SHORT_PRESS,
+    TRIPLE_PRESS,
+    TURN_ON,
+)
+
+ROTATED = "device_rotated"
+
+
+class IkeaSYMFONISK(CustomDevice):
+    """Custom device representing IKEA of Sweden TRADFRI remote control."""
+
+    signature = {
+        # <SimpleDescriptor endpoint=1 profile=260 device_type=6
+        # device_version=1
+        # input_clusters=[0, 1, 3, 32, 4096]
+        # output_clusters=[3, 4, 6, 8, 25, 4096]>
+        MODELS_INFO: [(IKEA, "SYMFONISK Sound Controller")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    PollControl.cluster_id,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    DoublingPowerConfigurationCluster,
+                    Identify.cluster_id,
+                    PollControl.cluster_id,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                    LightLink.cluster_id,
+                ],
+            }
+        }
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, TURN_ON): {
+            COMMAND: COMMAND_TOGGLE,
+            CLUSTER_ID: 6,
+            ENDPOINT_ID: 1,
+        },
+        (ROTATED, RIGHT): {
+            COMMAND: COMMAND_MOVE,
+            CLUSTER_ID: 8,
+            ENDPOINT_ID: 1,
+            ARGS: [0, 195],
+        },
+        (ROTATED, LEFT): {
+            COMMAND: COMMAND_MOVE,
+            CLUSTER_ID: 8,
+            ENDPOINT_ID: 1,
+            ARGS: [1, 195],
+        },
+        (DOUBLE_PRESS, TURN_ON): {
+            COMMAND: COMMAND_STEP,
+            CLUSTER_ID: 8,
+            ENDPOINT_ID: 1,
+            ARGS: [0, 1, 0],
+        },
+        (TRIPLE_PRESS, TURN_ON): {
+            COMMAND: COMMAND_STEP,
+            CLUSTER_ID: 8,
+            ENDPOINT_ID: 1,
+            ARGS: [1, 1, 0],
+        },
+    }

--- a/zhaquirks/konke/__init__.py
+++ b/zhaquirks/konke/__init__.py
@@ -1,31 +1,16 @@
 """Konke sensors."""
 
 import asyncio
-import logging
 
-from zigpy.quirks import CustomCluster, CustomDevice
-from zigpy.zcl.clusters.general import Basic, PowerConfiguration
-from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
-from zigpy.zcl.clusters.measurement import (
-    OccupancySensing,
-    PressureMeasurement,
-    RelativeHumidity,
-    TemperatureMeasurement,
-)
+from zigpy.quirks import CustomCluster
+from zigpy.zcl.clusters.measurement import OccupancySensing
 from zigpy.zcl.clusters.security import IasZone
 
-from .. import Bus, LocalDataCluster
+from .. import LocalDataCluster
 from ..const import (
-    ATTRIBUTE_ID,
-    ATTRIBUTE_NAME,
     CLUSTER_COMMAND,
-    COMMAND_ATTRIBUTE_UPDATED,
-    COMMAND_TRIPLE,
     OFF,
     ON,
-    UNKNOWN,
-    VALUE,
-    ZHA_SEND_EVENT,
     ZONE_STATE,
 )
 
@@ -37,6 +22,7 @@ ZONE_TYPE = 0x0001
 
 MOTION_TIME = 60
 OCCUPANCY_TIME = 600
+
 
 class OccupancyCluster(LocalDataCluster, OccupancySensing):
     """Occupancy cluster."""
@@ -57,7 +43,7 @@ class OccupancyCluster(LocalDataCluster, OccupancySensing):
             self._timer_handle.cancel()
 
         loop = asyncio.get_event_loop()
-        self._timer_handle = loop.call_later(OCCUPANCY_TIME, self._turn_off) #120
+        self._timer_handle = loop.call_later(OCCUPANCY_TIME, self._turn_off)
 
     def _turn_off(self):
         self._timer_handle = None

--- a/zhaquirks/konke/__init__.py
+++ b/zhaquirks/konke/__init__.py
@@ -1,0 +1,89 @@
+"""Konke sensors."""
+
+import asyncio
+import logging
+
+from zigpy.quirks import CustomCluster, CustomDevice
+from zigpy.zcl.clusters.general import Basic, PowerConfiguration
+from zigpy.zcl.clusters.homeautomation import ElectricalMeasurement
+from zigpy.zcl.clusters.measurement import (
+    OccupancySensing,
+    PressureMeasurement,
+    RelativeHumidity,
+    TemperatureMeasurement,
+)
+from zigpy.zcl.clusters.security import IasZone
+
+from .. import Bus, LocalDataCluster
+from ..const import (
+    ATTRIBUTE_ID,
+    ATTRIBUTE_NAME,
+    CLUSTER_COMMAND,
+    COMMAND_ATTRIBUTE_UPDATED,
+    COMMAND_TRIPLE,
+    OFF,
+    ON,
+    UNKNOWN,
+    VALUE,
+    ZHA_SEND_EVENT,
+    ZONE_STATE,
+)
+
+KONKE = "Konke"
+OCCUPANCY_STATE = 0
+OCCUPANCY_EVENT = "occupancy_event"
+MOTION_TYPE = 0x000D
+ZONE_TYPE = 0x0001
+
+MOTION_TIME = 60
+OCCUPANCY_TIME = 600
+
+class OccupancyCluster(LocalDataCluster, OccupancySensing):
+    """Occupancy cluster."""
+
+    cluster_id = OccupancySensing.cluster_id
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self._timer_handle = None
+        self.endpoint.device.occupancy_bus.add_listener(self)
+
+    def occupancy_event(self):
+        """Occupancy event."""
+        self._update_attribute(OCCUPANCY_STATE, ON)
+
+        if self._timer_handle:
+            self._timer_handle.cancel()
+
+        loop = asyncio.get_event_loop()
+        self._timer_handle = loop.call_later(OCCUPANCY_TIME, self._turn_off) #120
+
+    def _turn_off(self):
+        self._timer_handle = None
+        self._update_attribute(OCCUPANCY_STATE, OFF)
+
+
+class MotionCluster(CustomCluster, IasZone):
+    """Motion cluster."""
+
+    cluster_id = IasZone.cluster_id
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        super().__init__(*args, **kwargs)
+        self._timer_handle = None
+
+    def handle_cluster_request(self, tsn, command_id, args):
+        """Handle the cluster command."""
+        if command_id == 0:
+            if self._timer_handle:
+                self._timer_handle.cancel()
+            loop = asyncio.get_event_loop()
+            self._timer_handle = loop.call_later(MOTION_TIME, self._turn_off)
+            self.endpoint.device.occupancy_bus.listener_event(OCCUPANCY_EVENT)
+
+    def _turn_off(self):
+        self._timer_handle = None
+        self.listener_event(CLUSTER_COMMAND, 999, 0, [0, 0, 0, 0])
+        self._update_attribute(ZONE_STATE, OFF)

--- a/zhaquirks/konke/motion.py
+++ b/zhaquirks/konke/motion.py
@@ -1,0 +1,65 @@
+"""Konke motion sensor."""
+
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.general import Basic, Identify, PowerConfiguration
+from zigpy.zcl.clusters.security import IasZone
+
+from . import KONKE, MotionCluster, OccupancyCluster
+from .. import Bus
+from ..const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+KONKE_CLUSTER_ID = 0xFCC0
+
+class KonkeMotion(CustomDevice):
+    """Custom device representing konke motion sensors."""
+
+    def __init__(self, *args, **kwargs):
+        """Init."""
+        self.occupancy_bus = Bus()
+        super().__init__(*args, **kwargs)
+
+    signature = {
+        #  <SimpleDescriptor endpoint=1 profile=260 device_type=1026
+        #  device_version=0
+        #  input_clusters=[0, 1, 3, 1280, 64704]
+        #  output_clusters=[3, 64704]>
+        MODELS_INFO: [(KONKE, "3AFE28010402000D"), (KONKE, "3AFE14010402000D"), (KONKE, "3AFE27010402000D")],
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.IAS_ZONE,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    IasZone.cluster_id,
+                    KONKE_CLUSTER_ID
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, KONKE_CLUSTER_ID],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    OccupancyCluster,
+                    MotionCluster,
+                    KONKE_CLUSTER_ID
+                ],
+                OUTPUT_CLUSTERS: [Identify.cluster_id, KONKE_CLUSTER_ID],
+            }
+        }
+    }

--- a/zhaquirks/konke/motion.py
+++ b/zhaquirks/konke/motion.py
@@ -18,6 +18,7 @@ from ..const import (
 
 KONKE_CLUSTER_ID = 0xFCC0
 
+
 class KonkeMotion(CustomDevice):
     """Custom device representing konke motion sensors."""
 
@@ -31,7 +32,11 @@ class KonkeMotion(CustomDevice):
         #  device_version=0
         #  input_clusters=[0, 1, 3, 1280, 64704]
         #  output_clusters=[3, 64704]>
-        MODELS_INFO: [(KONKE, "3AFE28010402000D"), (KONKE, "3AFE14010402000D"), (KONKE, "3AFE27010402000D")],
+        MODELS_INFO: [
+            (KONKE, "3AFE28010402000D"),
+            (KONKE, "3AFE14010402000D"),
+            (KONKE, "3AFE27010402000D"),
+        ],
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
@@ -41,7 +46,7 @@ class KonkeMotion(CustomDevice):
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                     IasZone.cluster_id,
-                    KONKE_CLUSTER_ID
+                    KONKE_CLUSTER_ID,
                 ],
                 OUTPUT_CLUSTERS: [Identify.cluster_id, KONKE_CLUSTER_ID],
             }
@@ -57,7 +62,7 @@ class KonkeMotion(CustomDevice):
                     Identify.cluster_id,
                     OccupancyCluster,
                     MotionCluster,
-                    KONKE_CLUSTER_ID
+                    KONKE_CLUSTER_ID,
                 ],
                 OUTPUT_CLUSTERS: [Identify.cluster_id, KONKE_CLUSTER_ID],
             }


### PR DESCRIPTION
The Konke motion sensor only triggers an event on motion in the IasZone, but it is never going off.
This quirk adds a timed callback to turn the zone off again, and adds an occupancy cluster as well.

It seems like there are three device variants:
`(KONKE, "3AFE28010402000D"), (KONKE, "3AFE14010402000D"), (KONKE, "3AFE27010402000D`
I own the first one and it works fine. Got the other device infos from [zigbee-herdsman-converters](https://github.com/Koenkk/zigbee-herdsman-converters/blob/764eb3fff57365e1c97ee0c98007b6cb797048c7/devices.js).

i chose `MOTION_TIME = 60` and `OCCUPANCY_TIME = 600` as timeouts for the callbacks, as there was no common timeout I found in the other sensors.

The quirk is based on the Trust ZPIR-8000 and the lumi.sensor_motion quirks.