### PR TITLE
Add initial support for Philips Hue Smart Button (ROM001)

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -16,3 +16,4 @@
 - [Shulyaka] (https://github.com/Shulyaka)
 - [Nemesis24] (https://github.com/Nemesis24)
 - [Andy Zickler](https://github.com/andyzickler)
+- [Piotr Majkrzak](https://github.com/majkrzak)

--- a/zhaquirks/philips/rom001.py
+++ b/zhaquirks/philips/rom001.py
@@ -13,13 +13,7 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from ..const import (
-    DEVICE_TYPE,
-    ENDPOINTS,
-    INPUT_CLUSTERS,
-    OUTPUT_CLUSTERS,
-    PROFILE_ID,
-)
+from ..const import DEVICE_TYPE, ENDPOINTS, INPUT_CLUSTERS, OUTPUT_CLUSTERS, PROFILE_ID
 
 DEVICE_SPECIFIC_UNKNOWN = 64512
 
@@ -52,7 +46,7 @@ class PhilipsROM001(CustomDevice):
                     LevelControl.cluster_id,
                     Scenes.cluster_id,
                     LightLink.cluster_id,
-                ]
+                ],
             }
         }
     }
@@ -67,9 +61,7 @@ class PhilipsROM001(CustomDevice):
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
                 ],
-                OUTPUT_CLUSTERS: [
-                    OnOff.cluster_id,
-                ]
+                OUTPUT_CLUSTERS: [OnOff.cluster_id],
             }
         }
     }

--- a/zhaquirks/philips/rom001.py
+++ b/zhaquirks/philips/rom001.py
@@ -13,7 +13,19 @@ from zigpy.zcl.clusters.general import (
 )
 from zigpy.zcl.clusters.lightlink import LightLink
 
-from ..const import DEVICE_TYPE, ENDPOINTS, INPUT_CLUSTERS, OUTPUT_CLUSTERS, PROFILE_ID
+from ..const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+    SHORT_PRESS,
+    TURN_ON,
+    TURN_OFF,
+    COMMAND,
+    COMMAND_ON,
+    COMMAND_OFF_WITH_EFFECT,
+)
 
 DEVICE_SPECIFIC_UNKNOWN = 64512
 
@@ -55,13 +67,29 @@ class PhilipsROM001(CustomDevice):
         ENDPOINTS: {
             1: {
                 PROFILE_ID: zha.PROFILE_ID,
-                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_SCENE_CONTROLLER,
                 INPUT_CLUSTERS: [
                     Basic.cluster_id,
                     PowerConfiguration.cluster_id,
                     Identify.cluster_id,
+                    DEVICE_SPECIFIC_UNKNOWN,
+                    LightLink.cluster_id,
                 ],
-                OUTPUT_CLUSTERS: [OnOff.cluster_id],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Scenes.cluster_id,
+                    LightLink.cluster_id,
+                ],
             }
         }
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON},
+        (SHORT_PRESS, TURN_OFF): {COMMAND: COMMAND_OFF_WITH_EFFECT},
     }

--- a/zhaquirks/philips/rom001.py
+++ b/zhaquirks/philips/rom001.py
@@ -1,0 +1,75 @@
+"""Phillips ROM001 device."""
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Groups,
+    Identify,
+    LevelControl,
+    OnOff,
+    Ota,
+    PowerConfiguration,
+    Scenes,
+)
+from zigpy.zcl.clusters.lightlink import LightLink
+
+from ..const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+)
+
+DEVICE_SPECIFIC_UNKNOWN = 64512
+
+
+class PhilipsROM001(CustomDevice):
+    """Phillips ROM001 device."""
+
+    signature = {
+        #  <SimpleDescriptor endpoint=1 profile=260 device_type=2096
+        #  device_version=1
+        #  input_clusters=[0, 1, 3, 64512, 4096]
+        #  output_clusters=[25, 0, 3, 4, 6, 8, 5, 4096]>
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.NON_COLOR_SCENE_CONTROLLER,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    DEVICE_SPECIFIC_UNKNOWN,
+                    LightLink.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Ota.cluster_id,
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Scenes.cluster_id,
+                    LightLink.cluster_id,
+                ]
+            }
+        }
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    OnOff.cluster_id,
+                ]
+            }
+        }
+    }


### PR DESCRIPTION
Philips Hue Smart Button while connected to Home Assistant reports only battery status. As far as I understand how ZigBee works, this mapping should let it operate as a On/Off switch.

Based on data from #212