### PR TITLE
Add support for older Aqara WXKG03LM and WXKG02LM

### DIFF
--- a/zhaquirks/xiaomi/aqara/remote_b186acn01.py
+++ b/zhaquirks/xiaomi/aqara/remote_b186acn01.py
@@ -8,6 +8,7 @@ from zigpy.zcl.clusters.general import (
     Groups,
     Identify,
     MultistateInput,
+    OnOff,
     Ota,
     Scenes,
 )
@@ -138,7 +139,7 @@ class RemoteB186ACN01(XiaomiCustomDevice):
         SKIP_CONFIGURATION: True,
         ENDPOINTS: {
             1: {
-                DEVICE_TYPE: XIAOMI_DEVICE_TYPE,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
                 INPUT_CLUSTERS: [
                     BasicCluster,
                     PowerConfigurationCluster,
@@ -155,10 +156,11 @@ class RemoteB186ACN01(XiaomiCustomDevice):
                     Ota.cluster_id,
                     XIAOMI_CLUSTER_ID,
                     MultistateInputCluster,
+                    OnOff.cluster_id
                 ],
             },
             2: {
-                DEVICE_TYPE: XIAOMI_DEVICE_TYPE2,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
                 INPUT_CLUSTERS: [Identify.cluster_id, MultistateInputCluster],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
@@ -168,7 +170,7 @@ class RemoteB186ACN01(XiaomiCustomDevice):
                 ],
             },
             3: {
-                DEVICE_TYPE: XIAOMI_DEVICE_TYPE3,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
                 INPUT_CLUSTERS: [Identify.cluster_id, MultistateInputCluster],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,

--- a/zhaquirks/xiaomi/aqara/remote_b186acn01.py
+++ b/zhaquirks/xiaomi/aqara/remote_b186acn01.py
@@ -156,7 +156,7 @@ class RemoteB186ACN01(XiaomiCustomDevice):
                     Ota.cluster_id,
                     XIAOMI_CLUSTER_ID,
                     MultistateInputCluster,
-                    OnOff.cluster_id
+                    OnOff.cluster_id,
                 ],
             },
             2: {

--- a/zhaquirks/xiaomi/aqara/remote_b286acn01.py
+++ b/zhaquirks/xiaomi/aqara/remote_b286acn01.py
@@ -8,6 +8,7 @@ from zigpy.zcl.clusters.general import (
     Groups,
     Identify,
     MultistateInput,
+    OnOff,
     Ota,
     Scenes,
 )
@@ -153,7 +154,7 @@ class RemoteB286ACN01(XiaomiCustomDevice):
         SKIP_CONFIGURATION: True,
         ENDPOINTS: {
             1: {
-                DEVICE_TYPE: XIAOMI_DEVICE_TYPE,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
                 INPUT_CLUSTERS: [
                     BasicCluster,
                     PowerConfigurationCluster,
@@ -170,20 +171,22 @@ class RemoteB286ACN01(XiaomiCustomDevice):
                     Ota.cluster_id,
                     XIAOMI_CLUSTER_ID,
                     MultistateInputCluster,
+                    OnOff.cluster_id,
                 ],
             },
             2: {
-                DEVICE_TYPE: XIAOMI_DEVICE_TYPE2,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
                 INPUT_CLUSTERS: [Identify.cluster_id, MultistateInputCluster],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
                     Groups.cluster_id,
                     Scenes.cluster_id,
                     MultistateInputCluster,
+                    OnOff.cluster_id,
                 ],
             },
             3: {
-                DEVICE_TYPE: XIAOMI_DEVICE_TYPE3,
+                DEVICE_TYPE: zha.DeviceType.REMOTE_CONTROL,
                 INPUT_CLUSTERS: [Identify.cluster_id, MultistateInputCluster],
                 OUTPUT_CLUSTERS: [
                     Identify.cluster_id,
@@ -191,6 +194,7 @@ class RemoteB286ACN01(XiaomiCustomDevice):
                     Scenes.cluster_id,
                     AnalogInput.cluster_id,
                     MultistateInputCluster,
+                    OnOff.cluster_id,
                 ],
             },
         },


### PR DESCRIPTION
Add OnOff to OUTPUT_CLUSTERS to support older devices that send this command on click. Fixes #254