### PR TITLE
Limit Xiaomi PressureMeasurementCluster values

### DIFF
--- a/zhaquirks/xiaomi/__init__.py
+++ b/zhaquirks/xiaomi/__init__.py
@@ -404,6 +404,12 @@ class PressureMeasurementCluster(CustomCluster, PressureMeasurement):
         super().__init__(*args, **kwargs)
         self.endpoint.device.pressure_bus.add_listener(self)
 
+    def _update_attribute(self, attrid, value):
+        # drop values above and below documented range for this sensor
+        # value is in hectopascals
+        if attrid == self.ATTR_ID and (300 <= value <= 1100):
+            super()._update_attribute(attrid, value)
+
     def pressure_reported(self, value):
         """Pressure reported."""
         self._update_attribute(self.ATTR_ID, value)


### PR DESCRIPTION
According to docs (https://www.aqara.com/us/temperature_humidity_sensor.html) pressure range is 30 kPa – 110 kPa.

On current HA dev Xiaomi sensor returned values out of specs range (-1 or 10020-10040). After that fix everything went back to normal.

**Before:**
![image](https://user-images.githubusercontent.com/30175487/76257523-1d802880-6252-11ea-8636-39635044813b.png)
**After:**
![image](https://user-images.githubusercontent.com/30175487/76257756-9a130700-6252-11ea-8aba-e7e74125a755.png)

