### PR TITLE
Add support for the SAGE Doorbell (AKA Echostar Bell)

### DIFF
--- a/zhaquirks/echostar/__init__.py
+++ b/zhaquirks/echostar/__init__.py
@@ -1,0 +1,1 @@
+"""Module for Echostar quirks implementations."""

--- a/zhaquirks/echostar/bell.py
+++ b/zhaquirks/echostar/bell.py
@@ -83,5 +83,5 @@ class Bell(CustomDevice):
     }
     device_automation_triggers = {
         (SHORT_PRESS, BUTTON_1): {COMMAND: COMMAND_ON, CLUSTER_ID: 6, ENDPOINT_ID: 18},
-        (SHORT_PRESS, BUTTON_2): {COMMAND: COMMAND_OFF, CLUSTER_ID: 6, ENDPOINT_ID: 18}
+        (SHORT_PRESS, BUTTON_2): {COMMAND: COMMAND_OFF, CLUSTER_ID: 6, ENDPOINT_ID: 18},
     }

--- a/zhaquirks/echostar/bell.py
+++ b/zhaquirks/echostar/bell.py
@@ -12,9 +12,12 @@ from zigpy.zcl.clusters.general import (
 )
 
 from ..const import (
+    BUTTON_1,
+    BUTTON_2,
     CLUSTER_ID,
     COMMAND,
     COMMAND_ON,
+    COMMAND_OFF,
     DEVICE_TYPE,
     ENDPOINT_ID,
     ENDPOINTS,
@@ -23,7 +26,6 @@ from ..const import (
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SHORT_PRESS,
-    TURN_ON,
 )
 
 MANUFACTURER = " Echostar"
@@ -80,5 +82,6 @@ class Bell(CustomDevice):
         }
     }
     device_automation_triggers = {
-        (SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON, CLUSTER_ID: 6, ENDPOINT_ID: 18}
+        (SHORT_PRESS, BUTTON_1): {COMMAND: COMMAND_ON, CLUSTER_ID: 6, ENDPOINT_ID: 18},
+        (SHORT_PRESS, BUTTON_2): {COMMAND: COMMAND_OFF, CLUSTER_ID: 6, ENDPOINT_ID: 18}
     }

--- a/zhaquirks/echostar/bell.py
+++ b/zhaquirks/echostar/bell.py
@@ -3,17 +3,21 @@
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
+    Alarms,
     Basic,
     Identify,
-    Alarms,
-    OnOff,
     LevelControl,
+    OnOff,
     Ota,
     PowerConfiguration,
 )
 
 from ..const import (
+    CLUSTER_ID,
+    COMMAND,
+    COMMAND_ON,
     DEVICE_TYPE,
+    ENDPOINT_ID,
     ENDPOINTS,
     INPUT_CLUSTERS,
     MODELS_INFO,
@@ -21,10 +25,6 @@ from ..const import (
     PROFILE_ID,
     SHORT_PRESS,
     TURN_ON,
-    CLUSTER_ID,
-    ENDPOINT_ID,
-    COMMAND,
-    COMMAND_ON,
 )
 
 MANUFACTURER = " Echostar"

--- a/zhaquirks/echostar/bell.py
+++ b/zhaquirks/echostar/bell.py
@@ -1,0 +1,87 @@
+"""Echostar Bell Device"""
+"""Sage Doorbell Sensor Device"""
+
+from zigpy.profiles import zha
+from zigpy.quirks import CustomDevice
+from zigpy.zcl.clusters.general import (
+    Basic,
+    Identify,
+    Alarms,
+    OnOff,
+    LevelControl,
+    Ota,
+    PowerConfiguration,
+)
+
+from ..const import (
+    DEVICE_TYPE,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    MODELS_INFO,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+    SHORT_PRESS,
+    TURN_ON,
+    CLUSTER_ID,
+    ENDPOINT_ID,
+    COMMAND,
+    COMMAND_ON,
+    COMMAND_OFF,
+)
+
+MANUFACTURER = " Echostar"
+MODEL = "  Bell"
+
+
+class Bell(CustomDevice):
+    """Echostar Bell device"""
+
+    signature = {
+        # <SimpleDescriptor endpoint=18 profile=260 device_type=260
+        # device_version=0
+        # input_clusters=[0, 3, 9, 1]
+        # output_clusters=[3, 6, 8, 25]>
+        # MODELS_INFO: [(MANUFACTURER, MODEL)],
+        ENDPOINTS: {
+            18: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.DIMMER_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Alarms.cluster_id,
+                    PowerConfiguration.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                ],
+            }
+        },
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            18: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.ON_OFF_SWITCH,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Alarms.cluster_id,
+                    PowerConfiguration.cluster_id,
+                ],
+                OUTPUT_CLUSTERS: [
+                    Identify.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                    Ota.cluster_id,
+                ],
+            }
+        },
+    }
+    device_automation_triggers = {
+        (SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON, CLUSTER_ID: 6, ENDPOINT_ID: 18,},
+    }

--- a/zhaquirks/echostar/bell.py
+++ b/zhaquirks/echostar/bell.py
@@ -1,6 +1,5 @@
-"""Echostar Bell Device"""
-"""Sage Doorbell Sensor Device"""
-
+"""Echostar Bell Device."""
+"""Sage Doorbell Sensor Device."""
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (
@@ -26,7 +25,6 @@ from ..const import (
     ENDPOINT_ID,
     COMMAND,
     COMMAND_ON,
-    COMMAND_OFF,
 )
 
 MANUFACTURER = " Echostar"
@@ -34,7 +32,7 @@ MODEL = "   Bell"
 
 
 class Bell(CustomDevice):
-    """Echostar Bell device"""
+    """Echostar Bell device."""
 
     signature = {
         # <SimpleDescriptor endpoint=18 profile=260 device_type=260
@@ -83,5 +81,5 @@ class Bell(CustomDevice):
         },
     }
     device_automation_triggers = {
-        (SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON, CLUSTER_ID: 6, ENDPOINT_ID: 18,},
+        (SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON, CLUSTER_ID: 6, ENDPOINT_ID: 18, },
     }

--- a/zhaquirks/echostar/bell.py
+++ b/zhaquirks/echostar/bell.py
@@ -77,8 +77,8 @@ class Bell(CustomDevice):
                     Ota.cluster_id,
                 ],
             }
-        },
+        }
     }
     device_automation_triggers = {
-        (SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON, CLUSTER_ID: 6, ENDPOINT_ID: 18, },
+        (SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON, CLUSTER_ID: 6, ENDPOINT_ID: 18}
     }

--- a/zhaquirks/echostar/bell.py
+++ b/zhaquirks/echostar/bell.py
@@ -30,7 +30,7 @@ from ..const import (
 )
 
 MANUFACTURER = " Echostar"
-MODEL = "  Bell"
+MODEL = "   Bell"
 
 
 class Bell(CustomDevice):
@@ -41,7 +41,7 @@ class Bell(CustomDevice):
         # device_version=0
         # input_clusters=[0, 3, 9, 1]
         # output_clusters=[3, 6, 8, 25]>
-        # MODELS_INFO: [(MANUFACTURER, MODEL)],
+        MODELS_INFO: [(MANUFACTURER, MODEL)],
         ENDPOINTS: {
             18: {
                 PROFILE_ID: zha.PROFILE_ID,

--- a/zhaquirks/echostar/bell.py
+++ b/zhaquirks/echostar/bell.py
@@ -1,5 +1,4 @@
-"""Echostar Bell Device."""
-"""Sage Doorbell Sensor Device."""
+"""Echostar Sage Doorbell Sensor Device."""
 from zigpy.profiles import zha
 from zigpy.quirks import CustomDevice
 from zigpy.zcl.clusters.general import (


### PR DESCRIPTION
This quirk adds support for the SAGE Doorball (AKA Echostar Bell).

I only have the front door bell attached so I don't have the automation event code for the second doorbell.