### PR TITLE
Add support for the older rwl020 remote

### DIFF
--- a/zhaquirks/philips/rwl020.py
+++ b/zhaquirks/philips/rwl020.py
@@ -126,11 +126,6 @@ class PhilipsRWL020(CustomDevice):
             ENDPOINT_ID: 1,
             ARGS: [0, 56, 9],
         },
-        (LONG_RELEASE, "Dim Up/Down"): {
-            COMMAND: COMMAND_STOP,
-            ENDPOINT_ID: 1,
-            CLUSTER_ID: 8,
-        },
         (SHORT_PRESS, DIM_DOWN): {
             COMMAND: COMMAND_STEP,
             CLUSTER_ID: 8,

--- a/zhaquirks/philips/rwl020.py
+++ b/zhaquirks/philips/rwl020.py
@@ -1,0 +1,139 @@
+"""Phillips RWL020 device."""
+from zigpy.profiles import zha, zll
+from zigpy.quirks import CustomCluster, CustomDevice
+import zigpy.types as t
+from zigpy.zcl.clusters.general import (
+    Basic,
+    BinaryInput,
+    Groups,
+    Identify,
+    LevelControl,
+    OnOff,
+    Ota,
+    PowerConfiguration,
+)
+
+from ..const import (
+    ARGS,
+    CLUSTER_ID,
+    COMMAND,
+    COMMAND_OFF_WITH_EFFECT,
+    COMMAND_ON,
+    COMMAND_STEP,
+    DEVICE_TYPE,
+    DIM_DOWN,
+    DIM_UP,
+    ENDPOINT_ID,
+    ENDPOINTS,
+    INPUT_CLUSTERS,
+    LONG_PRESS,
+    OUTPUT_CLUSTERS,
+    PROFILE_ID,
+    SHORT_PRESS,
+    TURN_OFF,
+    TURN_ON,
+)
+
+DIAGNOSTICS_CLUSTER_ID = 0x0B05  # decimal = 2821
+
+
+class BasicCluster(CustomCluster, Basic):
+    """Centralite acceleration cluster."""
+
+    attributes = Basic.attributes.copy()
+    attributes.update({0x0031: ("phillips", t.bitmap16)})
+
+
+class PhilipsRWL020(CustomDevice):
+    """Phillips RWL020 device."""
+
+    signature = {
+        #  <SimpleDescriptor endpoint=1 profile=49246 device_type=2080
+        #  device_version=2
+        #  input_clusters=[0]
+        #  output_clusters=[0, 3, 4, 6, 8]>
+        ENDPOINTS: {
+            1: {
+                PROFILE_ID: zll.PROFILE_ID,
+                DEVICE_TYPE: zll.DeviceType.CONTROLLER,
+                INPUT_CLUSTERS: [Basic.cluster_id],
+                OUTPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                ],
+            },
+            #  <SimpleDescriptor endpoint=2 profile=260 device_type=12
+            #  device_version=0
+            #  input_clusters=[0, 1, 3, 15, 64512]
+            #  output_clusters=[25]>
+            2: {
+                PROFILE_ID: zha.PROFILE_ID,
+                DEVICE_TYPE: zha.DeviceType.SIMPLE_SENSOR,
+                INPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    BinaryInput.cluster_id,
+                    64512,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+        }
+    }
+
+    replacement = {
+        ENDPOINTS: {
+            1: {
+                INPUT_CLUSTERS: [Basic.cluster_id],
+                OUTPUT_CLUSTERS: [
+                    Basic.cluster_id,
+                    Identify.cluster_id,
+                    Groups.cluster_id,
+                    OnOff.cluster_id,
+                    LevelControl.cluster_id,
+                ],
+            },
+            2: {
+                INPUT_CLUSTERS: [
+                    BasicCluster,
+                    PowerConfiguration.cluster_id,
+                    Identify.cluster_id,
+                    BinaryInput.cluster_id,
+                    64512,
+                ],
+                OUTPUT_CLUSTERS: [Ota.cluster_id],
+            },
+        }
+    }
+
+    device_automation_triggers = {
+        (SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON},
+        (LONG_PRESS, TURN_OFF): {COMMAND: COMMAND_OFF_WITH_EFFECT},
+        (SHORT_PRESS, DIM_UP): {
+            COMMAND: COMMAND_STEP,
+            CLUSTER_ID: 8,
+            ENDPOINT_ID: 1,
+            ARGS: [0, 30, 9],
+        },
+        (LONG_PRESS, DIM_UP): {
+            COMMAND: COMMAND_STEP,
+            CLUSTER_ID: 8,
+            ENDPOINT_ID: 1,
+            ARGS: [0, 56, 9],
+        },
+        (SHORT_PRESS, DIM_DOWN): {
+            COMMAND: COMMAND_STEP,
+            CLUSTER_ID: 8,
+            ENDPOINT_ID: 1,
+            ARGS: [1, 30, 9],
+        },
+        (LONG_PRESS, DIM_DOWN): {
+            COMMAND: COMMAND_STEP,
+            CLUSTER_ID: 8,
+            ENDPOINT_ID: 1,
+            ARGS: [1, 56, 9],
+        },
+    }

--- a/zhaquirks/philips/rwl020.py
+++ b/zhaquirks/philips/rwl020.py
@@ -111,7 +111,7 @@ class PhilipsRWL020(CustomDevice):
 
     device_automation_triggers = {
         (SHORT_PRESS, TURN_ON): {COMMAND: COMMAND_ON},
-        (LONG_PRESS, TURN_OFF): {COMMAND: COMMAND_OFF_WITH_EFFECT},
+        (SHORT_PRESS, TURN_OFF): {COMMAND: COMMAND_OFF_WITH_EFFECT},
         (SHORT_PRESS, DIM_UP): {
             COMMAND: COMMAND_STEP,
             CLUSTER_ID: 8,

--- a/zhaquirks/philips/rwl020.py
+++ b/zhaquirks/philips/rwl020.py
@@ -20,7 +20,6 @@ from ..const import (
     COMMAND_OFF_WITH_EFFECT,
     COMMAND_ON,
     COMMAND_STEP,
-    COMMAND_STOP,
     DEVICE_TYPE,
     DIM_DOWN,
     DIM_UP,

--- a/zhaquirks/philips/rwl020.py
+++ b/zhaquirks/philips/rwl020.py
@@ -20,6 +20,7 @@ from ..const import (
     COMMAND_OFF_WITH_EFFECT,
     COMMAND_ON,
     COMMAND_STEP,
+    COMMAND_STOP,
     DEVICE_TYPE,
     DIM_DOWN,
     DIM_UP,
@@ -27,6 +28,7 @@ from ..const import (
     ENDPOINTS,
     INPUT_CLUSTERS,
     LONG_PRESS,
+    LONG_RELEASE,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SHORT_PRESS,
@@ -123,6 +125,11 @@ class PhilipsRWL020(CustomDevice):
             CLUSTER_ID: 8,
             ENDPOINT_ID: 1,
             ARGS: [0, 56, 9],
+        },
+        (LONG_RELEASE, "Dim Up/Down"): {
+            COMMAND: COMMAND_STOP,
+            ENDPOINT_ID: 1,
+            CLUSTER_ID: 8,
         },
         (SHORT_PRESS, DIM_DOWN): {
             COMMAND: COMMAND_STEP,

--- a/zhaquirks/philips/rwl020.py
+++ b/zhaquirks/philips/rwl020.py
@@ -28,7 +28,6 @@ from ..const import (
     ENDPOINTS,
     INPUT_CLUSTERS,
     LONG_PRESS,
-    LONG_RELEASE,
     OUTPUT_CLUSTERS,
     PROFILE_ID,
     SHORT_PRESS,


### PR DESCRIPTION
This adds support for a slightly older Philips hue remote that doesn't have the exact same support profile.  It is a simpler interface that does not support scenes.